### PR TITLE
Add quick response caching and retrieval logic in ChatService

### DIFF
--- a/drizzle/0011_free_nighthawk.sql
+++ b/drizzle/0011_free_nighthawk.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "quick_response" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"chat_id" uuid NOT NULL,
+	"assistant_message_id" uuid NOT NULL,
+	"responses" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "quick_response" ADD CONSTRAINT "quick_response_chat_id_chat_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."chat"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "quick_response" ADD CONSTRAINT "quick_response_assistant_message_id_chat_message_id_fk" FOREIGN KEY ("assistant_message_id") REFERENCES "public"."chat_message"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "quick_response_chat_id_assistant_message_id_index" ON "quick_response" USING btree ("chat_id","assistant_message_id");--> statement-breakpoint
+CREATE INDEX "quick_response_created_at_index" ON "quick_response" USING btree ("created_at");

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,588 @@
+{
+  "id": "76ee70df-056d-4f86-a21b-ad728a7b76cb",
+  "prevId": "afb75fd4-a6ef-45f9-b0b3-ca43657f785d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_message": {
+      "name": "chat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tool_data": {
+          "name": "tool_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_scope": {
+          "name": "message_scope",
+          "type": "message_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_message_chat_id_index": {
+          "name": "chat_message_chat_id_index",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_message_user_id_index": {
+          "name": "chat_message_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_message_user_id_created_at_index": {
+          "name": "chat_message_user_id_created_at_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_message_chat_id_chat_id_fk": {
+          "name": "chat_message_chat_id_chat_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_message_user_id_users_id_fk": {
+          "name": "chat_message_user_id_users_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "wellness_plan": {
+          "name": "wellness_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "chat_user_id_index": {
+          "name": "chat_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_user_id_users_id_fk": {
+          "name": "chat_user_id_users_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow_up": {
+      "name": "follow_up",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_up_user_id_index": {
+          "name": "follow_up_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_up_chat_id_index": {
+          "name": "follow_up_chat_id_index",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_up_due_date_index": {
+          "name": "follow_up_due_date_index",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_up_status_index": {
+          "name": "follow_up_status_index",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_up_user_id_users_id_fk": {
+          "name": "follow_up_user_id_users_id_fk",
+          "tableFrom": "follow_up",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_up_chat_id_chat_id_fk": {
+          "name": "follow_up_chat_id_chat_id_fk",
+          "tableFrom": "follow_up",
+          "tableTo": "chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quick_response": {
+      "name": "quick_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quick_response_chat_id_assistant_message_id_index": {
+          "name": "quick_response_chat_id_assistant_message_id_index",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assistant_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quick_response_created_at_index": {
+          "name": "quick_response_created_at_index",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quick_response_chat_id_chat_id_fk": {
+          "name": "quick_response_chat_id_chat_id_fk",
+          "tableFrom": "quick_response",
+          "tableTo": "chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quick_response_assistant_message_id_chat_message_id_fk": {
+          "name": "quick_response_assistant_message_id_chat_message_id_fk",
+          "tableFrom": "quick_response",
+          "tableTo": "chat_message",
+          "columnsFrom": [
+            "assistant_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Helsinki'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_onboarded": {
+          "name": "is_onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.follow_up_status": {
+      "name": "follow_up_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.message_scope": {
+      "name": "message_scope",
+      "schema": "public",
+      "values": [
+        "ONBOARDING",
+        "COACH"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1747379766246,
       "tag": "0010_stale_marauders",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1748946139683,
+      "tag": "0011_free_nighthawk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/chat/chat.controller.e2e.spec.ts
+++ b/src/chat/chat.controller.e2e.spec.ts
@@ -77,6 +77,17 @@ describe('ChatController (e2e)', () => {
       '## Wellness Plan\n\n- Drink more water\n- Exercise daily';
     chatService.getCurrentWellnessPlan.mockResolvedValue(mockWellnessPlan);
 
+    // Setup the mock for getQuickResponses
+    const mockQuickResponses = {
+      quickResponses: [
+        { text: 'That sounds great!' },
+        { text: 'Tell me more' },
+        { text: 'I need help' },
+        { text: 'Thanks!' },
+      ],
+    };
+    chatService.getQuickResponses.mockResolvedValue(mockQuickResponses);
+
     const moduleFixture: TestingModule = await createTestingModuleWithDb({
       imports: [ChatModule],
     })
@@ -229,6 +240,29 @@ describe('ChatController (e2e)', () => {
       expect(response.body).toEqual({
         wellnessPlan:
           '## Wellness Plan\n\n- Drink more water\n- Exercise daily',
+      });
+    });
+  });
+
+  describe('when getting quick responses', () => {
+    it('should return quick response options for the user', async () => {
+      // Make the request
+      const response = await request(app.getHttpServer())
+        .get('/api/chat/quick-responses')
+        .expect(200);
+
+      // Verify the service was called correctly
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(chatService.getQuickResponses).toHaveBeenCalledWith(mockUser.id);
+
+      // Verify the response body
+      expect(response.body).toEqual({
+        quickResponses: [
+          { text: 'That sounds great!' },
+          { text: 'Tell me more' },
+          { text: 'I need help' },
+          { text: 'Thanks!' },
+        ],
       });
     });
   });

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -29,6 +29,7 @@ import {
   ChatRequest,
 } from './dto/chat';
 import { ChatStateResponse } from './dto/chat-state.dto';
+import { QuickResponsesResponse } from './dto/quick-responses.dto';
 import { WellnessPlanResponse } from './dto/wellness-plan.dto';
 
 class ChatMessagesResponse extends PagedResult<ChatMessageResponse> {
@@ -154,5 +155,17 @@ export class ChatController {
   ): Promise<WellnessPlanResponse> {
     const wellnessPlan = await this.chatService.getCurrentWellnessPlan(user.id);
     return { wellnessPlan };
+  }
+
+  @Get('/quick-responses')
+  @ApiResponse({
+    status: 200,
+    type: QuickResponsesResponse,
+    description: 'Get quick response options for the current user',
+  })
+  async getQuickResponses(
+    @User() user: UserPrincipal,
+  ): Promise<QuickResponsesResponse> {
+    return this.chatService.getQuickResponses(user.id);
   }
 }

--- a/src/chat/chat/prompt.service.ts
+++ b/src/chat/chat/prompt.service.ts
@@ -406,4 +406,48 @@ ${toneAndFeel}
 
 You will next ask details about the user's profile, start by asking for the user's name.`;
   }
+
+  async getQuickResponseSystemPrompt(
+    userId: string,
+    lastAssistantMessage: string,
+    conversationContext: string[],
+  ): Promise<string> {
+    const userTimeZone = await this.getUserTimeZone(userId);
+    const userProfile = await this.getUserProfile(userId);
+    const isOnboarded = await this.getIsUserOnboarded(userId);
+
+    const userProfileInfo = this.formatUserProfileInfo(userProfile);
+
+    const contextMessages = conversationContext
+      .slice(-3) // Last 3 messages for context
+      .map((msg, index) => `${index + 1}. ${msg}`)
+      .join('\n');
+
+    return `
+# Current date and time: ${dateFnsTz.formatInTimeZone(new Date(), userTimeZone, 'yyyy-MM-dd HH:mm')}
+
+# Your Role & Purpose
+You are an AI assistant helping to generate quick response options for a wellness coaching chat app.
+
+# Task
+Generate 3-4 short, natural quick response options that a user might want to send in response to the last assistant message. The responses should:
+- Be conversational and natural
+- Be appropriate for a wellness coaching context
+- Be brief (3-8 words typically)
+- Reflect different types of responses (positive, questioning, requesting more info, etc.)
+- Be relevant to the conversation context
+
+# User Context
+${userProfileInfo}
+- User is ${isOnboarded ? 'onboarded' : 'completing onboarding'}
+
+# Recent Conversation Context
+${contextMessages}
+
+# Last Assistant Message
+"${lastAssistantMessage}"
+
+Generate diverse quick response options that give the user meaningful choices to continue the conversation naturally.
+`;
+  }
 }

--- a/src/chat/dto/quick-responses.dto.ts
+++ b/src/chat/dto/quick-responses.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsNotEmpty, IsString } from 'class-validator';
+
+export class QuickResponse {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: 'Quick response text',
+    example: 'That sounds great!',
+  })
+  text: string;
+}
+
+export class QuickResponsesResponse {
+  @IsArray()
+  @ApiProperty({
+    type: [QuickResponse],
+    description: 'Array of quick response options',
+  })
+  quickResponses: QuickResponse[];
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -81,6 +81,31 @@ export const chatMessages = pgTable(
   ],
 );
 
+// New table for caching quick responses
+export const quickResponses = pgTable(
+  'quick_response',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    chatId: uuid('chat_id')
+      .notNull()
+      .references(() => chats.id, { onDelete: 'cascade' }),
+    // The assistant message for which these quick responses were generated
+    assistantMessageId: uuid('assistant_message_id')
+      .notNull()
+      .references(() => chatMessages.id, { onDelete: 'cascade' }),
+    // Array of quick response strings
+    responses: jsonb('responses').$type<string[]>().notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (t) => [
+    index('quick_response_chat_id_assistant_message_id_index').on(
+      t.chatId,
+      t.assistantMessageId,
+    ),
+    index('quick_response_created_at_index').on(t.createdAt),
+  ],
+);
+
 // Follow up models
 export const followUps = pgTable(
   'follow_up',


### PR DESCRIPTION
- Introduced a new database table for caching quick responses linked to assistant messages.
- Updated ChatService to fetch cached responses or generate new ones based on recent conversation history.
- Enhanced unit tests to cover scenarios for cached responses and ensure correct functionality.
- Adjusted logging for better traceability of quick response generation and retrieval processes.