### PR TITLE
Enhance chat message retrieval with pagination support

### DIFF
--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -21,6 +21,7 @@ import { AuthGuard } from 'src/auth/auth/auth.guard';
 import { User } from 'src/auth/decorators';
 import { UserPrincipal } from 'src/auth/UserPrincipal';
 import { PagedResult } from 'src/db';
+import { PagedQuery } from 'src/db/pagination';
 import { ChatService } from './chat/chat.service';
 import {
   ChatChunkEventResponse,
@@ -119,19 +120,17 @@ export class ChatController {
   @ApiResponse({
     status: 200,
     type: ChatMessagesResponse,
-    isArray: true,
     description: 'Get all messages for the current user',
   })
   async getMessages(
     @User() user: UserPrincipal,
+    @Query() query: PagedQuery,
   ): Promise<ChatMessagesResponse> {
-    const messages = await this.chatService.getMessagesForUi(user.id);
-    return {
-      items: messages,
-      total: messages.length,
-      page: 0,
-      pageSize: messages.length,
-    };
+    return this.chatService.getMessagesForUi(
+      user.id,
+      query.page,
+      query.pageSize,
+    );
   }
 
   @Get('/state')

--- a/src/db/pagination.ts
+++ b/src/db/pagination.ts
@@ -1,5 +1,23 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
 import { PgSelect } from 'drizzle-orm/pg-core';
+
+export class PagedQuery {
+  @ApiProperty({ required: false, default: 0, type: Number })
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value, 10))
+  @IsInt()
+  @Min(0)
+  page?: number = 0;
+
+  @ApiProperty({ required: false, default: 10, type: Number })
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value, 10))
+  @IsInt()
+  @Min(1)
+  pageSize?: number = 10;
+}
 
 export function withPagination<T extends PgSelect>(
   qb: T,


### PR DESCRIPTION
- Updated ChatController to accept pagination parameters for fetching messages.
- Modified ChatService to return messages in a paginated format, including total count and page details.
- Improved unit tests to validate pagination behavior and ensure correct message retrieval based on page and pageSize.
- Introduced a PagedQuery class for handling pagination parameters in requests.