### PR TITLE
Filter out discontinued packages

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,9 +1,3 @@
-schema {
-  query: Query
-  mutation: Mutation
-  subscription: Subscription
-}
-
 scalar AWSDate
 scalar AWSTime
 scalar AWSDateTime
@@ -20,6 +14,12 @@ directive @aws_iam on FIELD_DEFINITION | OBJECT
 directive @aws_subscribe(mutations: [String!]!) on FIELD_DEFINITION
 directive @aws_auth(cognito_groups: [String!]) on FIELD_DEFINITION
 directive @aws_lambda on FIELD_DEFINITION | OBJECT
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
 
 type Address @aws_cognito_user_pools @aws_iam {
   city: String
@@ -52,12 +52,7 @@ type Customer @aws_cognito_user_pools @aws_iam {
   isSampleReady: Boolean
   languageCode: String
   lastName: String
-  orders(
-    filter: ModelOrderFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelOrderConnection
+  orders(filter: ModelOrderFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelOrderConnection
   owner: ID!
   phoneNumber: String!
   sample: Sample
@@ -125,10 +120,7 @@ type ModelPackageConnection @aws_api_key @aws_cognito_user_pools @aws_iam {
   nextToken: String
 }
 
-type ModelPackageProductConnection
-  @aws_api_key
-  @aws_cognito_user_pools
-  @aws_iam {
+type ModelPackageProductConnection @aws_api_key @aws_cognito_user_pools @aws_iam {
   items: [PackageProduct]!
   nextToken: String
 }
@@ -140,16 +132,6 @@ type ModelPaymentConnection @aws_cognito_user_pools @aws_iam {
 
 type ModelProductConnection @aws_api_key @aws_cognito_user_pools @aws_iam {
   items: [Product]!
-  nextToken: String
-}
-
-type ModelReportDataCustomerConnection @aws_cognito_user_pools @aws_iam {
-  items: [ReportDataCustomer]!
-  nextToken: String
-}
-
-type ModelReportDataOrderConnection @aws_cognito_user_pools @aws_iam {
-  items: [ReportDataOrder]!
   nextToken: String
 }
 
@@ -169,174 +151,42 @@ type ModelWebadminSampleConnection @aws_cognito_user_pools @aws_iam {
 }
 
 type Mutation {
-  createConfig(
-    condition: ModelConfigConditionInput
-    input: CreateConfigInput!
-  ): Config @aws_cognito_user_pools @aws_iam
-  createCustomer(
-    condition: ModelCustomerConditionInput
-    input: CreateCustomerInput!
-  ): Customer @aws_cognito_user_pools @aws_iam
-  createGiftOrder(
-    condition: ModelGiftOrderConditionInput
-    input: CreateGiftOrderInput!
-  ): GiftOrder @aws_cognito_user_pools @aws_iam
-  createOrder(
-    condition: ModelOrderConditionInput
-    input: CreateOrderInput!
-  ): Order @aws_cognito_user_pools @aws_iam
-  createOrderPackage(
-    condition: ModelOrderPackageConditionInput
-    input: CreateOrderPackageInput!
-  ): OrderPackage @aws_cognito_user_pools @aws_iam
-  createPackage(
-    condition: ModelPackageConditionInput
-    input: CreatePackageInput!
-  ): Package @aws_cognito_user_pools @aws_iam
-  createPackageProduct(
-    condition: ModelPackageProductConditionInput
-    input: CreatePackageProductInput!
-  ): PackageProduct @aws_cognito_user_pools @aws_iam
-  createPayment(
-    condition: ModelPaymentConditionInput
-    input: CreatePaymentInput!
-  ): Payment @aws_cognito_user_pools @aws_iam
-  createProduct(
-    condition: ModelProductConditionInput
-    input: CreateProductInput!
-  ): Product @aws_cognito_user_pools @aws_iam
-  createReportDataCustomer(
-    condition: ModelReportDataCustomerConditionInput
-    input: CreateReportDataCustomerInput!
-  ): ReportDataCustomer @aws_cognito_user_pools @aws_iam
-  createReportDataOrder(
-    condition: ModelReportDataOrderConditionInput
-    input: CreateReportDataOrderInput!
-  ): ReportDataOrder @aws_cognito_user_pools @aws_iam
-  createResult(
-    condition: ModelResultConditionInput
-    input: CreateResultInput!
-  ): Result @aws_cognito_user_pools @aws_iam
-  createSample(
-    condition: ModelSampleConditionInput
-    input: CreateSampleInput!
-  ): Sample @aws_cognito_user_pools @aws_iam
-  createWebadminSample(
-    condition: ModelWebadminSampleConditionInput
-    input: CreateWebadminSampleInput!
-  ): WebadminSample @aws_cognito_user_pools @aws_iam
-  deleteConfig(
-    condition: ModelConfigConditionInput
-    input: DeleteConfigInput!
-  ): Config @aws_cognito_user_pools @aws_iam
-  deleteCustomer(
-    condition: ModelCustomerConditionInput
-    input: DeleteCustomerInput!
-  ): Customer @aws_cognito_user_pools @aws_iam
-  deleteGiftOrder(
-    condition: ModelGiftOrderConditionInput
-    input: DeleteGiftOrderInput!
-  ): GiftOrder @aws_cognito_user_pools @aws_iam
-  deleteOrder(
-    condition: ModelOrderConditionInput
-    input: DeleteOrderInput!
-  ): Order @aws_cognito_user_pools @aws_iam
-  deleteOrderPackage(
-    condition: ModelOrderPackageConditionInput
-    input: DeleteOrderPackageInput!
-  ): OrderPackage @aws_cognito_user_pools @aws_iam
-  deletePackage(
-    condition: ModelPackageConditionInput
-    input: DeletePackageInput!
-  ): Package @aws_cognito_user_pools @aws_iam
-  deletePackageProduct(
-    condition: ModelPackageProductConditionInput
-    input: DeletePackageProductInput!
-  ): PackageProduct @aws_cognito_user_pools @aws_iam
-  deletePayment(
-    condition: ModelPaymentConditionInput
-    input: DeletePaymentInput!
-  ): Payment @aws_cognito_user_pools @aws_iam
-  deleteProduct(
-    condition: ModelProductConditionInput
-    input: DeleteProductInput!
-  ): Product @aws_cognito_user_pools @aws_iam
-  deleteReportDataCustomer(
-    condition: ModelReportDataCustomerConditionInput
-    input: DeleteReportDataCustomerInput!
-  ): ReportDataCustomer @aws_cognito_user_pools @aws_iam
-  deleteReportDataOrder(
-    condition: ModelReportDataOrderConditionInput
-    input: DeleteReportDataOrderInput!
-  ): ReportDataOrder @aws_cognito_user_pools @aws_iam
-  deleteResult(
-    condition: ModelResultConditionInput
-    input: DeleteResultInput!
-  ): Result @aws_cognito_user_pools @aws_iam
-  deleteSample(
-    condition: ModelSampleConditionInput
-    input: DeleteSampleInput!
-  ): Sample @aws_cognito_user_pools @aws_iam
-  deleteWebadminSample(
-    condition: ModelWebadminSampleConditionInput
-    input: DeleteWebadminSampleInput!
-  ): WebadminSample @aws_cognito_user_pools @aws_iam
-  updateConfig(
-    condition: ModelConfigConditionInput
-    input: UpdateConfigInput!
-  ): Config @aws_cognito_user_pools @aws_iam
-  updateCustomer(
-    condition: ModelCustomerConditionInput
-    input: UpdateCustomerInput!
-  ): Customer @aws_cognito_user_pools @aws_iam
-  updateGiftOrder(
-    condition: ModelGiftOrderConditionInput
-    input: UpdateGiftOrderInput!
-  ): GiftOrder @aws_cognito_user_pools @aws_iam
-  updateOrder(
-    condition: ModelOrderConditionInput
-    input: UpdateOrderInput!
-  ): Order @aws_cognito_user_pools @aws_iam
-  updateOrderPackage(
-    condition: ModelOrderPackageConditionInput
-    input: UpdateOrderPackageInput!
-  ): OrderPackage @aws_cognito_user_pools @aws_iam
-  updatePackage(
-    condition: ModelPackageConditionInput
-    input: UpdatePackageInput!
-  ): Package @aws_cognito_user_pools @aws_iam
-  updatePackageProduct(
-    condition: ModelPackageProductConditionInput
-    input: UpdatePackageProductInput!
-  ): PackageProduct @aws_cognito_user_pools @aws_iam
-  updatePayment(
-    condition: ModelPaymentConditionInput
-    input: UpdatePaymentInput!
-  ): Payment @aws_cognito_user_pools @aws_iam
-  updateProduct(
-    condition: ModelProductConditionInput
-    input: UpdateProductInput!
-  ): Product @aws_cognito_user_pools @aws_iam
-  updateReportDataCustomer(
-    condition: ModelReportDataCustomerConditionInput
-    input: UpdateReportDataCustomerInput!
-  ): ReportDataCustomer @aws_cognito_user_pools @aws_iam
-  updateReportDataOrder(
-    condition: ModelReportDataOrderConditionInput
-    input: UpdateReportDataOrderInput!
-  ): ReportDataOrder @aws_cognito_user_pools @aws_iam
-  updateResult(
-    condition: ModelResultConditionInput
-    input: UpdateResultInput!
-  ): Result @aws_cognito_user_pools @aws_iam
-  updateSample(
-    condition: ModelSampleConditionInput
-    input: UpdateSampleInput!
-  ): Sample @aws_cognito_user_pools @aws_iam
-  updateWebadminSample(
-    condition: ModelWebadminSampleConditionInput
-    input: UpdateWebadminSampleInput!
-  ): WebadminSample @aws_cognito_user_pools @aws_iam
+  createConfig(condition: ModelConfigConditionInput, input: CreateConfigInput!): Config @aws_cognito_user_pools @aws_iam
+  createCustomer(condition: ModelCustomerConditionInput, input: CreateCustomerInput!): Customer @aws_cognito_user_pools @aws_iam
+  createGiftOrder(condition: ModelGiftOrderConditionInput, input: CreateGiftOrderInput!): GiftOrder @aws_cognito_user_pools @aws_iam
+  createOrder(condition: ModelOrderConditionInput, input: CreateOrderInput!): Order @aws_cognito_user_pools @aws_iam
+  createOrderPackage(condition: ModelOrderPackageConditionInput, input: CreateOrderPackageInput!): OrderPackage @aws_cognito_user_pools @aws_iam
+  createPackage(condition: ModelPackageConditionInput, input: CreatePackageInput!): Package @aws_cognito_user_pools @aws_iam
+  createPackageProduct(condition: ModelPackageProductConditionInput, input: CreatePackageProductInput!): PackageProduct @aws_cognito_user_pools @aws_iam
+  createPayment(condition: ModelPaymentConditionInput, input: CreatePaymentInput!): Payment @aws_cognito_user_pools @aws_iam
+  createProduct(condition: ModelProductConditionInput, input: CreateProductInput!): Product @aws_cognito_user_pools @aws_iam
+  createResult(condition: ModelResultConditionInput, input: CreateResultInput!): Result @aws_cognito_user_pools @aws_iam
+  createSample(condition: ModelSampleConditionInput, input: CreateSampleInput!): Sample @aws_cognito_user_pools @aws_iam
+  createWebadminSample(condition: ModelWebadminSampleConditionInput, input: CreateWebadminSampleInput!): WebadminSample @aws_cognito_user_pools @aws_iam
+  deleteConfig(condition: ModelConfigConditionInput, input: DeleteConfigInput!): Config @aws_cognito_user_pools @aws_iam
+  deleteCustomer(condition: ModelCustomerConditionInput, input: DeleteCustomerInput!): Customer @aws_cognito_user_pools @aws_iam
+  deleteGiftOrder(condition: ModelGiftOrderConditionInput, input: DeleteGiftOrderInput!): GiftOrder @aws_cognito_user_pools @aws_iam
+  deleteOrder(condition: ModelOrderConditionInput, input: DeleteOrderInput!): Order @aws_cognito_user_pools @aws_iam
+  deleteOrderPackage(condition: ModelOrderPackageConditionInput, input: DeleteOrderPackageInput!): OrderPackage @aws_cognito_user_pools @aws_iam
+  deletePackage(condition: ModelPackageConditionInput, input: DeletePackageInput!): Package @aws_cognito_user_pools @aws_iam
+  deletePackageProduct(condition: ModelPackageProductConditionInput, input: DeletePackageProductInput!): PackageProduct @aws_cognito_user_pools @aws_iam
+  deletePayment(condition: ModelPaymentConditionInput, input: DeletePaymentInput!): Payment @aws_cognito_user_pools @aws_iam
+  deleteProduct(condition: ModelProductConditionInput, input: DeleteProductInput!): Product @aws_cognito_user_pools @aws_iam
+  deleteResult(condition: ModelResultConditionInput, input: DeleteResultInput!): Result @aws_cognito_user_pools @aws_iam
+  deleteSample(condition: ModelSampleConditionInput, input: DeleteSampleInput!): Sample @aws_cognito_user_pools @aws_iam
+  deleteWebadminSample(condition: ModelWebadminSampleConditionInput, input: DeleteWebadminSampleInput!): WebadminSample @aws_cognito_user_pools @aws_iam
+  updateConfig(condition: ModelConfigConditionInput, input: UpdateConfigInput!): Config @aws_cognito_user_pools @aws_iam
+  updateCustomer(condition: ModelCustomerConditionInput, input: UpdateCustomerInput!): Customer @aws_cognito_user_pools @aws_iam
+  updateGiftOrder(condition: ModelGiftOrderConditionInput, input: UpdateGiftOrderInput!): GiftOrder @aws_cognito_user_pools @aws_iam
+  updateOrder(condition: ModelOrderConditionInput, input: UpdateOrderInput!): Order @aws_cognito_user_pools @aws_iam
+  updateOrderPackage(condition: ModelOrderPackageConditionInput, input: UpdateOrderPackageInput!): OrderPackage @aws_cognito_user_pools @aws_iam
+  updatePackage(condition: ModelPackageConditionInput, input: UpdatePackageInput!): Package @aws_cognito_user_pools @aws_iam
+  updatePackageProduct(condition: ModelPackageProductConditionInput, input: UpdatePackageProductInput!): PackageProduct @aws_cognito_user_pools @aws_iam
+  updatePayment(condition: ModelPaymentConditionInput, input: UpdatePaymentInput!): Payment @aws_cognito_user_pools @aws_iam
+  updateProduct(condition: ModelProductConditionInput, input: UpdateProductInput!): Product @aws_cognito_user_pools @aws_iam
+  updateResult(condition: ModelResultConditionInput, input: UpdateResultInput!): Result @aws_cognito_user_pools @aws_iam
+  updateSample(condition: ModelSampleConditionInput, input: UpdateSampleInput!): Sample @aws_cognito_user_pools @aws_iam
+  updateWebadminSample(condition: ModelWebadminSampleConditionInput, input: UpdateWebadminSampleInput!): WebadminSample @aws_cognito_user_pools @aws_iam
 }
 
 type Order @aws_cognito_user_pools @aws_iam {
@@ -351,12 +201,7 @@ type Order @aws_cognito_user_pools @aws_iam {
   id: ID!
   mobile_pay_payment_id: ID
   owner: ID
-  packages(
-    filter: ModelOrderPackageFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelOrderPackageConnection
+  packages(filter: ModelOrderPackageFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelOrderPackageConnection
   postal_code: String
   stripe_payment_intent_id: String
   updatedAt: AWSDateTime!
@@ -380,23 +225,14 @@ type Package @aws_api_key @aws_cognito_user_pools @aws_iam {
   description: String
   id: ID!
   images: [AWSURL]
+  isDiscontinued: Boolean
   meta_data: String
   name: String
-  orders(
-    filter: ModelOrderPackageFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelOrderPackageConnection
+  orders(filter: ModelOrderPackageFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelOrderPackageConnection
   price: String
   productCode: Int
   productType: ProductType
-  products(
-    filter: ModelPackageProductFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelPackageProductConnection
+  products(filter: ModelPackageProductFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelPackageProductConnection
   short_description: String
   sku: String
   subText: String
@@ -424,7 +260,6 @@ type Payment @aws_cognito_user_pools @aws_iam {
   packageCodes: [Int]
   provider: PaymentProvider
   status: PaymentStatus
-  stripeMetadata: StripePaymentMetadata
   updatedAt: AWSDateTime!
   userId: ID
 }
@@ -436,21 +271,11 @@ type Product @aws_api_key @aws_cognito_user_pools @aws_iam {
   images: [AWSURL]
   meta_data: String
   name: String!
-  packages(
-    filter: ModelPackageProductFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelPackageProductConnection
+  packages(filter: ModelPackageProductFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelPackageProductConnection
   price: String
   productCode: String!
   productType: ProductType
-  results(
-    filter: ModelResultFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelResultConnection
+  results(filter: ModelResultFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelResultConnection
   short_description: String
   sku: String
   tax_class: String
@@ -458,264 +283,45 @@ type Product @aws_api_key @aws_cognito_user_pools @aws_iam {
 }
 
 type Query {
-  RDCustomerByMobAppCustomerId(
-    filter: ModelReportDataCustomerFilterInput
-    limit: Int
-    mobileAppCustomerId: ID!
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelReportDataCustomerConnection @aws_cognito_user_pools @aws_iam
-  customerByHasBoughtMainPackage(
-    compound_dateFirstMainPackageBought_id: ModelStringKeyConditionInput
-    filter: ModelCustomerFilterInput
-    hasBoughtMainPackage: Int!
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
-  customerByPhoneNumber(
-    filter: ModelCustomerFilterInput
-    limit: Int
-    nextToken: String
-    phoneNumber: String!
-    sortDirection: ModelSortDirection
-  ): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
-  customerScanByUpdatedAt(
-    filter: ModelCustomerFilterInput
-    limit: Int
-    nextToken: String
-    scanSortPrimaryKey: Int!
-    sortDirection: ModelSortDirection
-    updatedAt: ModelStringKeyConditionInput
-  ): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
+  customerByHasBoughtMainPackage(compound_dateFirstMainPackageBought_id: ModelStringKeyConditionInput, filter: ModelCustomerFilterInput, hasBoughtMainPackage: Int!, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
+  customerByPhoneNumber(filter: ModelCustomerFilterInput, limit: Int, nextToken: String, phoneNumber: String!, sortDirection: ModelSortDirection): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
+  customerScanByUpdatedAt(filter: ModelCustomerFilterInput, limit: Int, nextToken: String, scanSortPrimaryKey: Int!, sortDirection: ModelSortDirection, updatedAt: ModelStringKeyConditionInput): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
   getConfig(id: ID!): Config @aws_api_key @aws_cognito_user_pools @aws_iam
   getCustomer(id: ID!): Customer @aws_cognito_user_pools @aws_iam
-  getCustomerByCognitoSub(
-    filter: ModelCustomerFilterInput
-    limit: Int
-    nextToken: String
-    owner: ID!
-    sortDirection: ModelSortDirection
-  ): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
-  getCustomerByStripeId(
-    filter: ModelCustomerFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-    stripeId: String!
-  ): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
+  getCustomerByCognitoSub(filter: ModelCustomerFilterInput, limit: Int, nextToken: String, owner: ID!, sortDirection: ModelSortDirection): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
+  getCustomerByStripeId(filter: ModelCustomerFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection, stripeId: String!): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
   getGiftOrder(id: ID!): GiftOrder @aws_cognito_user_pools @aws_iam
   getOrder(id: ID!): Order @aws_cognito_user_pools @aws_iam
-  getOrderPackage(id: ID!): OrderPackage
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
+  getOrderPackage(id: ID!): OrderPackage @aws_api_key @aws_cognito_user_pools @aws_iam
   getPackage(id: ID!): Package @aws_api_key @aws_cognito_user_pools @aws_iam
-  getPackageProduct(id: ID!): PackageProduct
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
+  getPackageProduct(id: ID!): PackageProduct @aws_api_key @aws_cognito_user_pools @aws_iam
   getPayment(id: ID!): Payment @aws_cognito_user_pools @aws_iam
   getProduct(id: ID!): Product @aws_api_key @aws_cognito_user_pools @aws_iam
-  getProductByCode(
-    filter: ModelProductFilterInput
-    limit: Int
-    nextToken: String
-    productCode: String!
-    sortDirection: ModelSortDirection
-  ): ModelProductConnection @aws_api_key @aws_cognito_user_pools @aws_iam
-  getReportDataCustomer(id: ID!): ReportDataCustomer
-    @aws_cognito_user_pools
-    @aws_iam
-  getReportDataOrder(id: ID!): ReportDataOrder @aws_cognito_user_pools @aws_iam
+  getProductByCode(filter: ModelProductFilterInput, limit: Int, nextToken: String, productCode: String!, sortDirection: ModelSortDirection): ModelProductConnection @aws_api_key @aws_cognito_user_pools @aws_iam
   getResult(id: ID!): Result @aws_cognito_user_pools @aws_iam
   getSample(id: ID!): Sample @aws_cognito_user_pools @aws_iam
-  getSampleByName(
-    filter: ModelSampleFilterInput
-    limit: Int
-    name: String!
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelSampleConnection @aws_cognito_user_pools @aws_iam
+  getSampleByName(filter: ModelSampleFilterInput, limit: Int, name: String!, nextToken: String, sortDirection: ModelSortDirection): ModelSampleConnection @aws_cognito_user_pools @aws_iam
   getWebadminSample(id: ID!): WebadminSample @aws_cognito_user_pools @aws_iam
-  listConfigs(
-    filter: ModelConfigFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelConfigConnection @aws_api_key @aws_cognito_user_pools @aws_iam
-  listCustomers(
-    filter: ModelCustomerFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
-  listGiftOrders(
-    filter: ModelGiftOrderFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelGiftOrderConnection @aws_cognito_user_pools @aws_iam
-  listOrderPackages(
-    filter: ModelOrderPackageFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelOrderPackageConnection @aws_api_key @aws_cognito_user_pools @aws_iam
-  listOrders(
-    filter: ModelOrderFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelOrderConnection @aws_cognito_user_pools @aws_iam
-  listPackageProducts(
-    filter: ModelPackageProductFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelPackageProductConnection @aws_api_key @aws_cognito_user_pools @aws_iam
-  listPackages(
-    filter: ModelPackageFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelPackageConnection @aws_api_key @aws_cognito_user_pools @aws_iam
-  listPayments(
-    filter: ModelPaymentFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelPaymentConnection @aws_cognito_user_pools @aws_iam
-  listProducts(
-    filter: ModelProductFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelProductConnection @aws_api_key @aws_cognito_user_pools @aws_iam
-  listReportDataCustomers(
-    filter: ModelReportDataCustomerFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelReportDataCustomerConnection @aws_cognito_user_pools @aws_iam
-  listReportDataOrders(
-    filter: ModelReportDataOrderFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelReportDataOrderConnection @aws_cognito_user_pools @aws_iam
-  listResults(
-    filter: ModelResultFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelResultConnection @aws_cognito_user_pools @aws_iam
-  listSamples(
-    filter: ModelSampleFilterInput
-    limit: Int
-    nextToken: String
-  ): ModelSampleConnection @aws_cognito_user_pools @aws_iam
-  listWebadminSamples(
-    filter: ModelWebadminSampleFilterInput
-    id: ID
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelWebadminSampleConnection @aws_cognito_user_pools @aws_iam
-  orderByEPassiPayPaymentId(
-    epassi_payment_id: ID!
-    filter: ModelOrderFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelOrderConnection @aws_cognito_user_pools @aws_iam
-  orderByMobilePayPaymentId(
-    filter: ModelOrderFilterInput
-    limit: Int
-    mobile_pay_payment_id: ID!
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelOrderConnection @aws_cognito_user_pools @aws_iam
-  orderByOwner(
-    filter: ModelOrderFilterInput
-    id: ModelIDKeyConditionInput
-    limit: Int
-    nextToken: String
-    owner: ID!
-    sortDirection: ModelSortDirection
-  ): ModelOrderConnection @aws_cognito_user_pools @aws_iam
-  orderByStripePaymentIntentId(
-    filter: ModelOrderFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-    stripe_payment_intent_id: String!
-  ): ModelOrderConnection @aws_cognito_user_pools @aws_iam
-  packageByCode(
-    filter: ModelPackageFilterInput
-    limit: Int
-    nextToken: String
-    productCode: Int!
-    sortDirection: ModelSortDirection
-  ): ModelPackageConnection @aws_api_key @aws_cognito_user_pools @aws_iam
-  resultByOwner(
-    filter: ModelResultFilterInput
-    id: ModelIDKeyConditionInput
-    limit: Int
-    nextToken: String
-    owner: ID!
-    sortDirection: ModelSortDirection
-  ): ModelResultConnection @aws_cognito_user_pools @aws_iam
-  sampleByCustomer(
-    filter: ModelSampleFilterInput
-    id: ModelIDKeyConditionInput
-    limit: Int
-    nextToken: String
-    sampleCustomerId: ID!
-    sortDirection: ModelSortDirection
-  ): ModelSampleConnection @aws_cognito_user_pools @aws_iam
-  webadminSampleByCustomer(
-    filter: ModelWebadminSampleFilterInput
-    id: ModelIDKeyConditionInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-    webadminSampleCustomerId: ID!
-  ): ModelWebadminSampleConnection @aws_cognito_user_pools @aws_iam
-}
-
-type ReportDataCustomer @aws_cognito_user_pools @aws_iam {
-  address: Address
-  createdAt: AWSDateTime!
-  customer: Customer
-  email: String
-  firstName: String
-  id: ID!
-  language: String
-  lastName: String
-  mobileAppCustomerId: ID
-  orders(
-    filter: ModelReportDataOrderFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelReportDataOrderConnection
-  phoneNumber: String
-  resultsReadyDate: String
-  updatedAt: AWSDateTime!
-}
-
-type ReportDataOrder @aws_cognito_user_pools @aws_iam {
-  campaign: String
-  coupon: String
-  createdAt: AWSDateTime!
-  customer: ReportDataCustomer
-  details: String
-  discount: Float
-  id: ID!
-  mobileAppOrderId: Order
-  orderDate: String
-  orderSource: String
-  paymentMethod: String
-  price: Float
-  products: [ReportDataProduct]
-  reportDataCustomerOrdersId: ID
-  reportDataOrderMobileAppOrderIdId: ID
-  updatedAt: AWSDateTime!
-  vatRate: Float
-}
-
-type ReportDataProduct @aws_cognito_user_pools @aws_iam {
-  name: String
-  price: Float
+  listConfigs(filter: ModelConfigFilterInput, limit: Int, nextToken: String): ModelConfigConnection @aws_api_key @aws_cognito_user_pools @aws_iam
+  listCustomers(filter: ModelCustomerFilterInput, limit: Int, nextToken: String): ModelCustomerConnection @aws_cognito_user_pools @aws_iam
+  listGiftOrders(filter: ModelGiftOrderFilterInput, limit: Int, nextToken: String): ModelGiftOrderConnection @aws_cognito_user_pools @aws_iam
+  listOrderPackages(filter: ModelOrderPackageFilterInput, limit: Int, nextToken: String): ModelOrderPackageConnection @aws_api_key @aws_cognito_user_pools @aws_iam
+  listOrders(filter: ModelOrderFilterInput, limit: Int, nextToken: String): ModelOrderConnection @aws_cognito_user_pools @aws_iam
+  listPackageProducts(filter: ModelPackageProductFilterInput, limit: Int, nextToken: String): ModelPackageProductConnection @aws_api_key @aws_cognito_user_pools @aws_iam
+  listPackages(filter: ModelPackageFilterInput, limit: Int, nextToken: String): ModelPackageConnection @aws_api_key @aws_cognito_user_pools @aws_iam
+  listPayments(filter: ModelPaymentFilterInput, limit: Int, nextToken: String): ModelPaymentConnection @aws_cognito_user_pools @aws_iam
+  listProducts(filter: ModelProductFilterInput, limit: Int, nextToken: String): ModelProductConnection @aws_api_key @aws_cognito_user_pools @aws_iam
+  listResults(filter: ModelResultFilterInput, limit: Int, nextToken: String): ModelResultConnection @aws_cognito_user_pools @aws_iam
+  listSamples(filter: ModelSampleFilterInput, limit: Int, nextToken: String): ModelSampleConnection @aws_cognito_user_pools @aws_iam
+  listWebadminSamples(filter: ModelWebadminSampleFilterInput, id: ID, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelWebadminSampleConnection @aws_cognito_user_pools @aws_iam
+  orderByEPassiPayPaymentId(epassi_payment_id: ID!, filter: ModelOrderFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelOrderConnection @aws_cognito_user_pools @aws_iam
+  orderByMobilePayPaymentId(filter: ModelOrderFilterInput, limit: Int, mobile_pay_payment_id: ID!, nextToken: String, sortDirection: ModelSortDirection): ModelOrderConnection @aws_cognito_user_pools @aws_iam
+  orderByOwner(filter: ModelOrderFilterInput, id: ModelIDKeyConditionInput, limit: Int, nextToken: String, owner: ID!, sortDirection: ModelSortDirection): ModelOrderConnection @aws_cognito_user_pools @aws_iam
+  orderByStripePaymentIntentId(filter: ModelOrderFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection, stripe_payment_intent_id: String!): ModelOrderConnection @aws_cognito_user_pools @aws_iam
+  packageByCode(filter: ModelPackageFilterInput, limit: Int, nextToken: String, productCode: Int!, sortDirection: ModelSortDirection): ModelPackageConnection @aws_api_key @aws_cognito_user_pools @aws_iam
+  resultByOwner(filter: ModelResultFilterInput, id: ModelIDKeyConditionInput, limit: Int, nextToken: String, owner: ID!, sortDirection: ModelSortDirection): ModelResultConnection @aws_cognito_user_pools @aws_iam
+  sampleByCustomer(filter: ModelSampleFilterInput, id: ModelIDKeyConditionInput, limit: Int, nextToken: String, sampleCustomerId: ID!, sortDirection: ModelSortDirection): ModelSampleConnection @aws_cognito_user_pools @aws_iam
+  webadminSampleByCustomer(filter: ModelWebadminSampleFilterInput, id: ModelIDKeyConditionInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection, webadminSampleCustomerId: ID!): ModelWebadminSampleConnection @aws_cognito_user_pools @aws_iam
 }
 
 type Result @aws_cognito_user_pools @aws_iam {
@@ -738,295 +344,49 @@ type Sample @aws_cognito_user_pools @aws_iam {
   name: String!
   owner: ID
   phoneNumber: AWSPhone!
-  results(
-    filter: ModelResultFilterInput
-    limit: Int
-    nextToken: String
-    sortDirection: ModelSortDirection
-  ): ModelResultConnection
+  results(filter: ModelResultFilterInput, limit: Int, nextToken: String, sortDirection: ModelSortDirection): ModelResultConnection
   sampleCustomerId: ID
   status: SampleStatus
   updatedAt: AWSDateTime!
 }
 
-type StripePaymentMetadata @aws_cognito_user_pools @aws_iam {
-  paymentIntentId: String
-}
-
 type Subscription {
-  onCreateConfig(filter: ModelSubscriptionConfigFilterInput): Config
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createConfig"])
-  onCreateCustomer(
-    filter: ModelSubscriptionCustomerFilterInput
-    owner: String
-  ): Customer
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createCustomer"])
-  onCreateGiftOrder(
-    filter: ModelSubscriptionGiftOrderFilterInput
-    owner: String
-  ): GiftOrder
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createGiftOrder"])
-  onCreateOrder(
-    filter: ModelSubscriptionOrderFilterInput
-    owner: String
-  ): Order
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createOrder"])
-  onCreateOrderPackage(
-    filter: ModelSubscriptionOrderPackageFilterInput
-    owner: String
-  ): OrderPackage
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createOrderPackage"])
-  onCreatePackage(filter: ModelSubscriptionPackageFilterInput): Package
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createPackage"])
-  onCreatePackageProduct(
-    filter: ModelSubscriptionPackageProductFilterInput
-  ): PackageProduct
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createPackageProduct"])
-  onCreatePayment(
-    filter: ModelSubscriptionPaymentFilterInput
-    userId: String
-  ): Payment
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createPayment"])
-  onCreateProduct(filter: ModelSubscriptionProductFilterInput): Product
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createProduct"])
-  onCreateReportDataCustomer(
-    filter: ModelSubscriptionReportDataCustomerFilterInput
-  ): ReportDataCustomer
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createReportDataCustomer"])
-  onCreateReportDataOrder(
-    filter: ModelSubscriptionReportDataOrderFilterInput
-  ): ReportDataOrder
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createReportDataOrder"])
-  onCreateResult(
-    filter: ModelSubscriptionResultFilterInput
-    owner: String
-  ): Result
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createResult"])
-  onCreateSample(
-    filter: ModelSubscriptionSampleFilterInput
-    owner: String
-  ): Sample
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createSample"])
-  onCreateWebadminSample(
-    filter: ModelSubscriptionWebadminSampleFilterInput
-    webadminSampleCustomerId: String
-  ): WebadminSample
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["createWebadminSample"])
-  onDeleteConfig(filter: ModelSubscriptionConfigFilterInput): Config
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteConfig"])
-  onDeleteCustomer(
-    filter: ModelSubscriptionCustomerFilterInput
-    owner: String
-  ): Customer
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteCustomer"])
-  onDeleteGiftOrder(
-    filter: ModelSubscriptionGiftOrderFilterInput
-    owner: String
-  ): GiftOrder
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteGiftOrder"])
-  onDeleteOrder(
-    filter: ModelSubscriptionOrderFilterInput
-    owner: String
-  ): Order
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteOrder"])
-  onDeleteOrderPackage(
-    filter: ModelSubscriptionOrderPackageFilterInput
-    owner: String
-  ): OrderPackage
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteOrderPackage"])
-  onDeletePackage(filter: ModelSubscriptionPackageFilterInput): Package
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deletePackage"])
-  onDeletePackageProduct(
-    filter: ModelSubscriptionPackageProductFilterInput
-  ): PackageProduct
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deletePackageProduct"])
-  onDeletePayment(
-    filter: ModelSubscriptionPaymentFilterInput
-    userId: String
-  ): Payment
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deletePayment"])
-  onDeleteProduct(filter: ModelSubscriptionProductFilterInput): Product
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteProduct"])
-  onDeleteReportDataCustomer(
-    filter: ModelSubscriptionReportDataCustomerFilterInput
-  ): ReportDataCustomer
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteReportDataCustomer"])
-  onDeleteReportDataOrder(
-    filter: ModelSubscriptionReportDataOrderFilterInput
-  ): ReportDataOrder
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteReportDataOrder"])
-  onDeleteResult(
-    filter: ModelSubscriptionResultFilterInput
-    owner: String
-  ): Result
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteResult"])
-  onDeleteSample(
-    filter: ModelSubscriptionSampleFilterInput
-    owner: String
-  ): Sample
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteSample"])
-  onDeleteWebadminSample(
-    filter: ModelSubscriptionWebadminSampleFilterInput
-    webadminSampleCustomerId: String
-  ): WebadminSample
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["deleteWebadminSample"])
-  onUpdateConfig(filter: ModelSubscriptionConfigFilterInput): Config
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateConfig"])
-  onUpdateCustomer(
-    filter: ModelSubscriptionCustomerFilterInput
-    owner: String
-  ): Customer
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateCustomer"])
-  onUpdateGiftOrder(
-    filter: ModelSubscriptionGiftOrderFilterInput
-    owner: String
-  ): GiftOrder
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateGiftOrder"])
-  onUpdateOrder(
-    filter: ModelSubscriptionOrderFilterInput
-    owner: String
-  ): Order
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateOrder"])
-  onUpdateOrderPackage(
-    filter: ModelSubscriptionOrderPackageFilterInput
-    owner: String
-  ): OrderPackage
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateOrderPackage"])
-  onUpdatePackage(filter: ModelSubscriptionPackageFilterInput): Package
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updatePackage"])
-  onUpdatePackageProduct(
-    filter: ModelSubscriptionPackageProductFilterInput
-  ): PackageProduct
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updatePackageProduct"])
-  onUpdatePayment(
-    filter: ModelSubscriptionPaymentFilterInput
-    userId: String
-  ): Payment
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updatePayment"])
-  onUpdateProduct(filter: ModelSubscriptionProductFilterInput): Product
-    @aws_api_key
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateProduct"])
-  onUpdateReportDataCustomer(
-    filter: ModelSubscriptionReportDataCustomerFilterInput
-  ): ReportDataCustomer
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateReportDataCustomer"])
-  onUpdateReportDataOrder(
-    filter: ModelSubscriptionReportDataOrderFilterInput
-  ): ReportDataOrder
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateReportDataOrder"])
-  onUpdateResult(
-    filter: ModelSubscriptionResultFilterInput
-    owner: String
-  ): Result
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateResult"])
-  onUpdateSample(
-    filter: ModelSubscriptionSampleFilterInput
-    owner: String
-  ): Sample
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateSample"])
-  onUpdateWebadminSample(
-    filter: ModelSubscriptionWebadminSampleFilterInput
-    webadminSampleCustomerId: String
-  ): WebadminSample
-    @aws_cognito_user_pools
-    @aws_iam
-    @aws_subscribe(mutations: ["updateWebadminSample"])
+  onCreateConfig(filter: ModelSubscriptionConfigFilterInput): Config @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createConfig"])
+  onCreateCustomer(filter: ModelSubscriptionCustomerFilterInput, owner: String): Customer @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createCustomer"])
+  onCreateGiftOrder(filter: ModelSubscriptionGiftOrderFilterInput, owner: String): GiftOrder @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createGiftOrder"])
+  onCreateOrder(filter: ModelSubscriptionOrderFilterInput, owner: String): Order @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createOrder"])
+  onCreateOrderPackage(filter: ModelSubscriptionOrderPackageFilterInput, owner: String): OrderPackage @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createOrderPackage"])
+  onCreatePackage(filter: ModelSubscriptionPackageFilterInput): Package @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createPackage"])
+  onCreatePackageProduct(filter: ModelSubscriptionPackageProductFilterInput): PackageProduct @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createPackageProduct"])
+  onCreatePayment(filter: ModelSubscriptionPaymentFilterInput, userId: String): Payment @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createPayment"])
+  onCreateProduct(filter: ModelSubscriptionProductFilterInput): Product @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createProduct"])
+  onCreateResult(filter: ModelSubscriptionResultFilterInput, owner: String): Result @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createResult"])
+  onCreateSample(filter: ModelSubscriptionSampleFilterInput, owner: String): Sample @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createSample"])
+  onCreateWebadminSample(filter: ModelSubscriptionWebadminSampleFilterInput, webadminSampleCustomerId: String): WebadminSample @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["createWebadminSample"])
+  onDeleteConfig(filter: ModelSubscriptionConfigFilterInput): Config @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deleteConfig"])
+  onDeleteCustomer(filter: ModelSubscriptionCustomerFilterInput, owner: String): Customer @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deleteCustomer"])
+  onDeleteGiftOrder(filter: ModelSubscriptionGiftOrderFilterInput, owner: String): GiftOrder @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deleteGiftOrder"])
+  onDeleteOrder(filter: ModelSubscriptionOrderFilterInput, owner: String): Order @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deleteOrder"])
+  onDeleteOrderPackage(filter: ModelSubscriptionOrderPackageFilterInput, owner: String): OrderPackage @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deleteOrderPackage"])
+  onDeletePackage(filter: ModelSubscriptionPackageFilterInput): Package @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deletePackage"])
+  onDeletePackageProduct(filter: ModelSubscriptionPackageProductFilterInput): PackageProduct @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deletePackageProduct"])
+  onDeletePayment(filter: ModelSubscriptionPaymentFilterInput, userId: String): Payment @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deletePayment"])
+  onDeleteProduct(filter: ModelSubscriptionProductFilterInput): Product @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deleteProduct"])
+  onDeleteResult(filter: ModelSubscriptionResultFilterInput, owner: String): Result @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deleteResult"])
+  onDeleteSample(filter: ModelSubscriptionSampleFilterInput, owner: String): Sample @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deleteSample"])
+  onDeleteWebadminSample(filter: ModelSubscriptionWebadminSampleFilterInput, webadminSampleCustomerId: String): WebadminSample @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["deleteWebadminSample"])
+  onUpdateConfig(filter: ModelSubscriptionConfigFilterInput): Config @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updateConfig"])
+  onUpdateCustomer(filter: ModelSubscriptionCustomerFilterInput, owner: String): Customer @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updateCustomer"])
+  onUpdateGiftOrder(filter: ModelSubscriptionGiftOrderFilterInput, owner: String): GiftOrder @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updateGiftOrder"])
+  onUpdateOrder(filter: ModelSubscriptionOrderFilterInput, owner: String): Order @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updateOrder"])
+  onUpdateOrderPackage(filter: ModelSubscriptionOrderPackageFilterInput, owner: String): OrderPackage @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updateOrderPackage"])
+  onUpdatePackage(filter: ModelSubscriptionPackageFilterInput): Package @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updatePackage"])
+  onUpdatePackageProduct(filter: ModelSubscriptionPackageProductFilterInput): PackageProduct @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updatePackageProduct"])
+  onUpdatePayment(filter: ModelSubscriptionPaymentFilterInput, userId: String): Payment @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updatePayment"])
+  onUpdateProduct(filter: ModelSubscriptionProductFilterInput): Product @aws_api_key @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updateProduct"])
+  onUpdateResult(filter: ModelSubscriptionResultFilterInput, owner: String): Result @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updateResult"])
+  onUpdateSample(filter: ModelSubscriptionSampleFilterInput, owner: String): Sample @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updateSample"])
+  onUpdateWebadminSample(filter: ModelSubscriptionWebadminSampleFilterInput, webadminSampleCustomerId: String): WebadminSample @aws_cognito_user_pools @aws_iam @aws_subscribe(mutations : ["updateWebadminSample"])
 }
 
 type WebadminSample @aws_cognito_user_pools @aws_iam {
@@ -1160,6 +520,7 @@ input CreatePackageInput {
   description: String
   id: ID
   images: [AWSURL]
+  isDiscontinued: Boolean
   meta_data: String
   name: String
   price: String
@@ -1186,7 +547,6 @@ input CreatePaymentInput {
   packageCodes: [Int]
   provider: PaymentProvider
   status: PaymentStatus
-  stripeMetadata: StripePaymentMetadataInput
   userId: ID
 }
 
@@ -1202,34 +562,6 @@ input CreateProductInput {
   short_description: String
   sku: String
   tax_class: String
-}
-
-input CreateReportDataCustomerInput {
-  address: AddressInput
-  email: String
-  firstName: String
-  id: ID
-  language: String
-  lastName: String
-  mobileAppCustomerId: ID
-  phoneNumber: String
-  resultsReadyDate: String
-}
-
-input CreateReportDataOrderInput {
-  campaign: String
-  coupon: String
-  details: String
-  discount: Float
-  id: ID
-  orderDate: String
-  orderSource: String
-  paymentMethod: String
-  price: Float
-  products: [ReportDataProductInput]
-  reportDataCustomerOrdersId: ID
-  reportDataOrderMobileAppOrderIdId: ID
-  vatRate: Float
 }
 
 input CreateResultInput {
@@ -1293,14 +625,6 @@ input DeletePaymentInput {
 }
 
 input DeleteProductInput {
-  id: ID!
-}
-
-input DeleteReportDataCustomerInput {
-  id: ID!
-}
-
-input DeleteReportDataOrderInput {
   id: ID!
 }
 
@@ -1550,6 +874,7 @@ input ModelPackageConditionInput {
   createdAt: ModelStringInput
   description: ModelStringInput
   images: ModelStringInput
+  isDiscontinued: ModelBooleanInput
   meta_data: ModelStringInput
   name: ModelStringInput
   not: ModelPackageConditionInput
@@ -1570,6 +895,7 @@ input ModelPackageFilterInput {
   description: ModelStringInput
   id: ModelIDInput
   images: ModelStringInput
+  isDiscontinued: ModelBooleanInput
   meta_data: ModelStringInput
   name: ModelStringInput
   not: ModelPackageFilterInput
@@ -1684,76 +1010,6 @@ input ModelProductFilterInput {
 input ModelProductTypeInput {
   eq: ProductType
   ne: ProductType
-}
-
-input ModelReportDataCustomerConditionInput {
-  and: [ModelReportDataCustomerConditionInput]
-  createdAt: ModelStringInput
-  email: ModelStringInput
-  firstName: ModelStringInput
-  language: ModelStringInput
-  lastName: ModelStringInput
-  mobileAppCustomerId: ModelIDInput
-  not: ModelReportDataCustomerConditionInput
-  or: [ModelReportDataCustomerConditionInput]
-  phoneNumber: ModelStringInput
-  resultsReadyDate: ModelStringInput
-  updatedAt: ModelStringInput
-}
-
-input ModelReportDataCustomerFilterInput {
-  and: [ModelReportDataCustomerFilterInput]
-  createdAt: ModelStringInput
-  email: ModelStringInput
-  firstName: ModelStringInput
-  id: ModelIDInput
-  language: ModelStringInput
-  lastName: ModelStringInput
-  mobileAppCustomerId: ModelIDInput
-  not: ModelReportDataCustomerFilterInput
-  or: [ModelReportDataCustomerFilterInput]
-  phoneNumber: ModelStringInput
-  resultsReadyDate: ModelStringInput
-  updatedAt: ModelStringInput
-}
-
-input ModelReportDataOrderConditionInput {
-  and: [ModelReportDataOrderConditionInput]
-  campaign: ModelStringInput
-  coupon: ModelStringInput
-  createdAt: ModelStringInput
-  details: ModelStringInput
-  discount: ModelFloatInput
-  not: ModelReportDataOrderConditionInput
-  or: [ModelReportDataOrderConditionInput]
-  orderDate: ModelStringInput
-  orderSource: ModelStringInput
-  paymentMethod: ModelStringInput
-  price: ModelFloatInput
-  reportDataCustomerOrdersId: ModelIDInput
-  reportDataOrderMobileAppOrderIdId: ModelIDInput
-  updatedAt: ModelStringInput
-  vatRate: ModelFloatInput
-}
-
-input ModelReportDataOrderFilterInput {
-  and: [ModelReportDataOrderFilterInput]
-  campaign: ModelStringInput
-  coupon: ModelStringInput
-  createdAt: ModelStringInput
-  details: ModelStringInput
-  discount: ModelFloatInput
-  id: ModelIDInput
-  not: ModelReportDataOrderFilterInput
-  or: [ModelReportDataOrderFilterInput]
-  orderDate: ModelStringInput
-  orderSource: ModelStringInput
-  paymentMethod: ModelStringInput
-  price: ModelFloatInput
-  reportDataCustomerOrdersId: ModelIDInput
-  reportDataOrderMobileAppOrderIdId: ModelIDInput
-  updatedAt: ModelStringInput
-  vatRate: ModelFloatInput
 }
 
 input ModelResultConditionInput {
@@ -1980,6 +1236,7 @@ input ModelSubscriptionPackageFilterInput {
   description: ModelSubscriptionStringInput
   id: ModelSubscriptionIDInput
   images: ModelSubscriptionStringInput
+  isDiscontinued: ModelSubscriptionBooleanInput
   meta_data: ModelSubscriptionStringInput
   name: ModelSubscriptionStringInput
   or: [ModelSubscriptionPackageFilterInput]
@@ -2034,40 +1291,6 @@ input ModelSubscriptionProductFilterInput {
   sku: ModelSubscriptionStringInput
   tax_class: ModelSubscriptionStringInput
   updatedAt: ModelSubscriptionStringInput
-}
-
-input ModelSubscriptionReportDataCustomerFilterInput {
-  and: [ModelSubscriptionReportDataCustomerFilterInput]
-  createdAt: ModelSubscriptionStringInput
-  email: ModelSubscriptionStringInput
-  firstName: ModelSubscriptionStringInput
-  id: ModelSubscriptionIDInput
-  language: ModelSubscriptionStringInput
-  lastName: ModelSubscriptionStringInput
-  mobileAppCustomerId: ModelSubscriptionIDInput
-  or: [ModelSubscriptionReportDataCustomerFilterInput]
-  phoneNumber: ModelSubscriptionStringInput
-  reportDataCustomerOrdersId: ModelSubscriptionIDInput
-  resultsReadyDate: ModelSubscriptionStringInput
-  updatedAt: ModelSubscriptionStringInput
-}
-
-input ModelSubscriptionReportDataOrderFilterInput {
-  and: [ModelSubscriptionReportDataOrderFilterInput]
-  campaign: ModelSubscriptionStringInput
-  coupon: ModelSubscriptionStringInput
-  createdAt: ModelSubscriptionStringInput
-  details: ModelSubscriptionStringInput
-  discount: ModelSubscriptionFloatInput
-  id: ModelSubscriptionIDInput
-  or: [ModelSubscriptionReportDataOrderFilterInput]
-  orderDate: ModelSubscriptionStringInput
-  orderSource: ModelSubscriptionStringInput
-  paymentMethod: ModelSubscriptionStringInput
-  price: ModelSubscriptionFloatInput
-  reportDataOrderMobileAppOrderIdId: ModelSubscriptionIDInput
-  updatedAt: ModelSubscriptionStringInput
-  vatRate: ModelSubscriptionFloatInput
 }
 
 input ModelSubscriptionResultFilterInput {
@@ -2154,15 +1377,6 @@ input ModelWebadminSampleStatusInput {
   ne: WebadminSampleStatus
 }
 
-input ReportDataProductInput {
-  name: String
-  price: Float
-}
-
-input StripePaymentMetadataInput {
-  paymentIntentId: String
-}
-
 input UpdateConfigInput {
   data: AWSJSON
   id: String!
@@ -2223,6 +1437,7 @@ input UpdatePackageInput {
   description: String
   id: ID!
   images: [AWSURL]
+  isDiscontinued: Boolean
   meta_data: String
   name: String
   price: String
@@ -2249,7 +1464,6 @@ input UpdatePaymentInput {
   packageCodes: [Int]
   provider: PaymentProvider
   status: PaymentStatus
-  stripeMetadata: StripePaymentMetadataInput
   userId: ID
 }
 
@@ -2265,34 +1479,6 @@ input UpdateProductInput {
   short_description: String
   sku: String
   tax_class: String
-}
-
-input UpdateReportDataCustomerInput {
-  address: AddressInput
-  email: String
-  firstName: String
-  id: ID!
-  language: String
-  lastName: String
-  mobileAppCustomerId: ID
-  phoneNumber: String
-  resultsReadyDate: String
-}
-
-input UpdateReportDataOrderInput {
-  campaign: String
-  coupon: String
-  details: String
-  discount: Float
-  id: ID!
-  orderDate: String
-  orderSource: String
-  paymentMethod: String
-  price: Float
-  products: [ReportDataProductInput]
-  reportDataCustomerOrdersId: ID
-  reportDataOrderMobileAppOrderIdId: ID
-  vatRate: Float
 }
 
 input UpdateResultInput {

--- a/src/chat/chat/result.service.ts
+++ b/src/chat/chat/result.service.ts
@@ -106,6 +106,20 @@ export class ResultService {
           evogenomProduct.productCode === undefined
         )
           return null;
+
+        // Check if the product has any active (non-discontinued) packages
+        const hasActivePackages =
+          evogenomProduct.packages?.items?.some(
+            (packageItem) =>
+              packageItem?.package &&
+              (packageItem.package.isDiscontinued === false ||
+                packageItem.package.isDiscontinued === null),
+          ) ?? false;
+
+        if (!hasActivePackages) {
+          return null; // Filter out results for products with only discontinued packages
+        }
+
         return {
           productCode: String(evogenomProduct.productCode),
           productName: evogenomProduct.name || 'Unknown Product',

--- a/src/contentful/generated/types.ts
+++ b/src/contentful/generated/types.ts
@@ -870,12 +870,19 @@ export enum NotificationsOrder {
 export type Package = Entry & _Node & {
   __typename?: 'Package';
   _id: Scalars['ID']['output'];
+  cardDescription: Maybe<PackageCardDescription>;
   contentfulMetadata: ContentfulMetadata;
   linkedFrom: Maybe<PackageLinkingCollections>;
   name: Maybe<Scalars['String']['output']>;
   packageCode: Maybe<Scalars['Int']['output']>;
   subtitle: Maybe<Scalars['String']['output']>;
   sys: Sys;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/nslj8lsfnbof/content_types/package) */
+export type PackageCardDescriptionArgs = {
+  locale: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -902,6 +909,54 @@ export type PackageSubtitleArgs = {
   locale: InputMaybe<Scalars['String']['input']>;
 };
 
+export type PackageCardDescription = {
+  __typename?: 'PackageCardDescription';
+  json: Scalars['JSON']['output'];
+  links: PackageCardDescriptionLinks;
+};
+
+export type PackageCardDescriptionAssets = {
+  __typename?: 'PackageCardDescriptionAssets';
+  block: Array<Maybe<Asset>>;
+  hyperlink: Array<Maybe<Asset>>;
+};
+
+export type PackageCardDescriptionEntries = {
+  __typename?: 'PackageCardDescriptionEntries';
+  block: Array<Maybe<Entry>>;
+  hyperlink: Array<Maybe<Entry>>;
+  inline: Array<Maybe<Entry>>;
+};
+
+export type PackageCardDescriptionLinks = {
+  __typename?: 'PackageCardDescriptionLinks';
+  assets: PackageCardDescriptionAssets;
+  entries: PackageCardDescriptionEntries;
+  resources: PackageCardDescriptionResources;
+};
+
+export type PackageCardDescriptionResources = {
+  __typename?: 'PackageCardDescriptionResources';
+  block: Array<PackageCardDescriptionResourcesBlock>;
+  hyperlink: Array<PackageCardDescriptionResourcesHyperlink>;
+  inline: Array<PackageCardDescriptionResourcesInline>;
+};
+
+export type PackageCardDescriptionResourcesBlock = ResourceLink & {
+  __typename?: 'PackageCardDescriptionResourcesBlock';
+  sys: ResourceSys;
+};
+
+export type PackageCardDescriptionResourcesHyperlink = ResourceLink & {
+  __typename?: 'PackageCardDescriptionResourcesHyperlink';
+  sys: ResourceSys;
+};
+
+export type PackageCardDescriptionResourcesInline = ResourceLink & {
+  __typename?: 'PackageCardDescriptionResourcesInline';
+  sys: ResourceSys;
+};
+
 export type PackageCollection = {
   __typename?: 'PackageCollection';
   items: Array<Maybe<Package>>;
@@ -913,6 +968,9 @@ export type PackageCollection = {
 export type PackageFilter = {
   AND: InputMaybe<Array<InputMaybe<PackageFilter>>>;
   OR: InputMaybe<Array<InputMaybe<PackageFilter>>>;
+  cardDescription_contains: InputMaybe<Scalars['String']['input']>;
+  cardDescription_exists: InputMaybe<Scalars['Boolean']['input']>;
+  cardDescription_not_contains: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata: InputMaybe<ContentfulMetadataFilter>;
   name: InputMaybe<Scalars['String']['input']>;
   name_contains: InputMaybe<Scalars['String']['input']>;
@@ -1079,6 +1137,8 @@ export type Query = {
   productCollection: Maybe<ProductCollection>;
   resultRow: Maybe<ResultRow>;
   resultRowCollection: Maybe<ResultRowCollection>;
+  wellnessCoachWelcomeMessage: Maybe<WellnessCoachWelcomeMessage>;
+  wellnessCoachWelcomeMessageCollection: Maybe<WellnessCoachWelcomeMessageCollection>;
 };
 
 
@@ -1239,6 +1299,23 @@ export type QueryResultRowCollectionArgs = {
   preview: InputMaybe<Scalars['Boolean']['input']>;
   skip?: InputMaybe<Scalars['Int']['input']>;
   where: InputMaybe<ResultRowFilter>;
+};
+
+
+export type QueryWellnessCoachWelcomeMessageArgs = {
+  id: Scalars['String']['input'];
+  locale: InputMaybe<Scalars['String']['input']>;
+  preview: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type QueryWellnessCoachWelcomeMessageCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale: InputMaybe<Scalars['String']['input']>;
+  order: InputMaybe<Array<InputMaybe<WellnessCoachWelcomeMessageOrder>>>;
+  preview: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where: InputMaybe<WellnessCoachWelcomeMessageFilter>;
 };
 
 export type ResourceLink = {
@@ -1496,6 +1573,104 @@ export type TaxonomyConcept = {
   __typename?: 'TaxonomyConcept';
   id: Maybe<Scalars['String']['output']>;
 };
+
+/** Wellcome message displayed by the wellness coach in the mobile app [See type definition](https://app.contentful.com/spaces/nslj8lsfnbof/content_types/wellnessCoachWelcomeMessage) */
+export type WellnessCoachWelcomeMessage = Entry & _Node & {
+  __typename?: 'WellnessCoachWelcomeMessage';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  exampleQuestions: Maybe<Scalars['String']['output']>;
+  exampleQuestionsText: Maybe<Scalars['String']['output']>;
+  linkedFrom: Maybe<WellnessCoachWelcomeMessageLinkingCollections>;
+  sys: Sys;
+  title: Maybe<Scalars['String']['output']>;
+};
+
+
+/** Wellcome message displayed by the wellness coach in the mobile app [See type definition](https://app.contentful.com/spaces/nslj8lsfnbof/content_types/wellnessCoachWelcomeMessage) */
+export type WellnessCoachWelcomeMessageExampleQuestionsArgs = {
+  locale: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** Wellcome message displayed by the wellness coach in the mobile app [See type definition](https://app.contentful.com/spaces/nslj8lsfnbof/content_types/wellnessCoachWelcomeMessage) */
+export type WellnessCoachWelcomeMessageExampleQuestionsTextArgs = {
+  locale: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** Wellcome message displayed by the wellness coach in the mobile app [See type definition](https://app.contentful.com/spaces/nslj8lsfnbof/content_types/wellnessCoachWelcomeMessage) */
+export type WellnessCoachWelcomeMessageLinkedFromArgs = {
+  allowedLocales: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** Wellcome message displayed by the wellness coach in the mobile app [See type definition](https://app.contentful.com/spaces/nslj8lsfnbof/content_types/wellnessCoachWelcomeMessage) */
+export type WellnessCoachWelcomeMessageTitleArgs = {
+  locale: InputMaybe<Scalars['String']['input']>;
+};
+
+export type WellnessCoachWelcomeMessageCollection = {
+  __typename?: 'WellnessCoachWelcomeMessageCollection';
+  items: Array<Maybe<WellnessCoachWelcomeMessage>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type WellnessCoachWelcomeMessageFilter = {
+  AND: InputMaybe<Array<InputMaybe<WellnessCoachWelcomeMessageFilter>>>;
+  OR: InputMaybe<Array<InputMaybe<WellnessCoachWelcomeMessageFilter>>>;
+  contentfulMetadata: InputMaybe<ContentfulMetadataFilter>;
+  exampleQuestions: InputMaybe<Scalars['String']['input']>;
+  exampleQuestionsText: InputMaybe<Scalars['String']['input']>;
+  exampleQuestionsText_contains: InputMaybe<Scalars['String']['input']>;
+  exampleQuestionsText_exists: InputMaybe<Scalars['Boolean']['input']>;
+  exampleQuestionsText_in: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  exampleQuestionsText_not: InputMaybe<Scalars['String']['input']>;
+  exampleQuestionsText_not_contains: InputMaybe<Scalars['String']['input']>;
+  exampleQuestionsText_not_in: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  exampleQuestions_contains: InputMaybe<Scalars['String']['input']>;
+  exampleQuestions_exists: InputMaybe<Scalars['Boolean']['input']>;
+  exampleQuestions_in: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  exampleQuestions_not: InputMaybe<Scalars['String']['input']>;
+  exampleQuestions_not_contains: InputMaybe<Scalars['String']['input']>;
+  exampleQuestions_not_in: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  sys: InputMaybe<SysFilter>;
+  title: InputMaybe<Scalars['String']['input']>;
+  title_contains: InputMaybe<Scalars['String']['input']>;
+  title_exists: InputMaybe<Scalars['Boolean']['input']>;
+  title_in: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not: InputMaybe<Scalars['String']['input']>;
+  title_not_contains: InputMaybe<Scalars['String']['input']>;
+  title_not_in: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type WellnessCoachWelcomeMessageLinkingCollections = {
+  __typename?: 'WellnessCoachWelcomeMessageLinkingCollections';
+  entryCollection: Maybe<EntryCollection>;
+};
+
+
+export type WellnessCoachWelcomeMessageLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale: InputMaybe<Scalars['String']['input']>;
+  preview: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export enum WellnessCoachWelcomeMessageOrder {
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
 
 export type _Node = {
   _id: Scalars['ID']['output'];

--- a/src/evogenom-api-client/generated/request.ts
+++ b/src/evogenom-api-client/generated/request.ts
@@ -115,6 +115,7 @@ export type CreatePackageInput = {
   description: InputMaybe<Scalars['String']['input']>;
   id: InputMaybe<Scalars['ID']['input']>;
   images: InputMaybe<Array<InputMaybe<Scalars['AWSURL']['input']>>>;
+  isDiscontinued: InputMaybe<Scalars['Boolean']['input']>;
   meta_data: InputMaybe<Scalars['String']['input']>;
   name: InputMaybe<Scalars['String']['input']>;
   price: InputMaybe<Scalars['String']['input']>;
@@ -141,7 +142,6 @@ export type CreatePaymentInput = {
   packageCodes: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
   provider: InputMaybe<PaymentProvider>;
   status: InputMaybe<PaymentStatus>;
-  stripeMetadata: InputMaybe<StripePaymentMetadataInput>;
   userId: InputMaybe<Scalars['ID']['input']>;
 };
 
@@ -157,34 +157,6 @@ export type CreateProductInput = {
   short_description: InputMaybe<Scalars['String']['input']>;
   sku: InputMaybe<Scalars['String']['input']>;
   tax_class: InputMaybe<Scalars['String']['input']>;
-};
-
-export type CreateReportDataCustomerInput = {
-  address: InputMaybe<AddressInput>;
-  email: InputMaybe<Scalars['String']['input']>;
-  firstName: InputMaybe<Scalars['String']['input']>;
-  id: InputMaybe<Scalars['ID']['input']>;
-  language: InputMaybe<Scalars['String']['input']>;
-  lastName: InputMaybe<Scalars['String']['input']>;
-  mobileAppCustomerId: InputMaybe<Scalars['ID']['input']>;
-  phoneNumber: InputMaybe<Scalars['String']['input']>;
-  resultsReadyDate: InputMaybe<Scalars['String']['input']>;
-};
-
-export type CreateReportDataOrderInput = {
-  campaign: InputMaybe<Scalars['String']['input']>;
-  coupon: InputMaybe<Scalars['String']['input']>;
-  details: InputMaybe<Scalars['String']['input']>;
-  discount: InputMaybe<Scalars['Float']['input']>;
-  id: InputMaybe<Scalars['ID']['input']>;
-  orderDate: InputMaybe<Scalars['String']['input']>;
-  orderSource: InputMaybe<Scalars['String']['input']>;
-  paymentMethod: InputMaybe<Scalars['String']['input']>;
-  price: InputMaybe<Scalars['Float']['input']>;
-  products: InputMaybe<Array<InputMaybe<ReportDataProductInput>>>;
-  reportDataCustomerOrdersId: InputMaybe<Scalars['ID']['input']>;
-  reportDataOrderMobileAppOrderIdId: InputMaybe<Scalars['ID']['input']>;
-  vatRate: InputMaybe<Scalars['Float']['input']>;
 };
 
 export type CreateResultInput = {
@@ -282,14 +254,6 @@ export type DeletePaymentInput = {
 };
 
 export type DeleteProductInput = {
-  id: Scalars['ID']['input'];
-};
-
-export type DeleteReportDataCustomerInput = {
-  id: Scalars['ID']['input'];
-};
-
-export type DeleteReportDataOrderInput = {
   id: Scalars['ID']['input'];
 };
 
@@ -613,6 +577,7 @@ export type ModelPackageConditionInput = {
   createdAt: InputMaybe<ModelStringInput>;
   description: InputMaybe<ModelStringInput>;
   images: InputMaybe<ModelStringInput>;
+  isDiscontinued: InputMaybe<ModelBooleanInput>;
   meta_data: InputMaybe<ModelStringInput>;
   name: InputMaybe<ModelStringInput>;
   not: InputMaybe<ModelPackageConditionInput>;
@@ -639,6 +604,7 @@ export type ModelPackageFilterInput = {
   description: InputMaybe<ModelStringInput>;
   id: InputMaybe<ModelIdInput>;
   images: InputMaybe<ModelStringInput>;
+  isDiscontinued: InputMaybe<ModelBooleanInput>;
   meta_data: InputMaybe<ModelStringInput>;
   name: InputMaybe<ModelStringInput>;
   not: InputMaybe<ModelPackageFilterInput>;
@@ -771,88 +737,6 @@ export type ModelProductFilterInput = {
 export type ModelProductTypeInput = {
   eq: InputMaybe<ProductType>;
   ne: InputMaybe<ProductType>;
-};
-
-export type ModelReportDataCustomerConditionInput = {
-  and: InputMaybe<Array<InputMaybe<ModelReportDataCustomerConditionInput>>>;
-  createdAt: InputMaybe<ModelStringInput>;
-  email: InputMaybe<ModelStringInput>;
-  firstName: InputMaybe<ModelStringInput>;
-  language: InputMaybe<ModelStringInput>;
-  lastName: InputMaybe<ModelStringInput>;
-  mobileAppCustomerId: InputMaybe<ModelIdInput>;
-  not: InputMaybe<ModelReportDataCustomerConditionInput>;
-  or: InputMaybe<Array<InputMaybe<ModelReportDataCustomerConditionInput>>>;
-  phoneNumber: InputMaybe<ModelStringInput>;
-  resultsReadyDate: InputMaybe<ModelStringInput>;
-  updatedAt: InputMaybe<ModelStringInput>;
-};
-
-export type ModelReportDataCustomerConnection = {
-  __typename?: 'ModelReportDataCustomerConnection';
-  items: Array<Maybe<ReportDataCustomer>>;
-  nextToken: Maybe<Scalars['String']['output']>;
-};
-
-export type ModelReportDataCustomerFilterInput = {
-  and: InputMaybe<Array<InputMaybe<ModelReportDataCustomerFilterInput>>>;
-  createdAt: InputMaybe<ModelStringInput>;
-  email: InputMaybe<ModelStringInput>;
-  firstName: InputMaybe<ModelStringInput>;
-  id: InputMaybe<ModelIdInput>;
-  language: InputMaybe<ModelStringInput>;
-  lastName: InputMaybe<ModelStringInput>;
-  mobileAppCustomerId: InputMaybe<ModelIdInput>;
-  not: InputMaybe<ModelReportDataCustomerFilterInput>;
-  or: InputMaybe<Array<InputMaybe<ModelReportDataCustomerFilterInput>>>;
-  phoneNumber: InputMaybe<ModelStringInput>;
-  resultsReadyDate: InputMaybe<ModelStringInput>;
-  updatedAt: InputMaybe<ModelStringInput>;
-};
-
-export type ModelReportDataOrderConditionInput = {
-  and: InputMaybe<Array<InputMaybe<ModelReportDataOrderConditionInput>>>;
-  campaign: InputMaybe<ModelStringInput>;
-  coupon: InputMaybe<ModelStringInput>;
-  createdAt: InputMaybe<ModelStringInput>;
-  details: InputMaybe<ModelStringInput>;
-  discount: InputMaybe<ModelFloatInput>;
-  not: InputMaybe<ModelReportDataOrderConditionInput>;
-  or: InputMaybe<Array<InputMaybe<ModelReportDataOrderConditionInput>>>;
-  orderDate: InputMaybe<ModelStringInput>;
-  orderSource: InputMaybe<ModelStringInput>;
-  paymentMethod: InputMaybe<ModelStringInput>;
-  price: InputMaybe<ModelFloatInput>;
-  reportDataCustomerOrdersId: InputMaybe<ModelIdInput>;
-  reportDataOrderMobileAppOrderIdId: InputMaybe<ModelIdInput>;
-  updatedAt: InputMaybe<ModelStringInput>;
-  vatRate: InputMaybe<ModelFloatInput>;
-};
-
-export type ModelReportDataOrderConnection = {
-  __typename?: 'ModelReportDataOrderConnection';
-  items: Array<Maybe<ReportDataOrder>>;
-  nextToken: Maybe<Scalars['String']['output']>;
-};
-
-export type ModelReportDataOrderFilterInput = {
-  and: InputMaybe<Array<InputMaybe<ModelReportDataOrderFilterInput>>>;
-  campaign: InputMaybe<ModelStringInput>;
-  coupon: InputMaybe<ModelStringInput>;
-  createdAt: InputMaybe<ModelStringInput>;
-  details: InputMaybe<ModelStringInput>;
-  discount: InputMaybe<ModelFloatInput>;
-  id: InputMaybe<ModelIdInput>;
-  not: InputMaybe<ModelReportDataOrderFilterInput>;
-  or: InputMaybe<Array<InputMaybe<ModelReportDataOrderFilterInput>>>;
-  orderDate: InputMaybe<ModelStringInput>;
-  orderSource: InputMaybe<ModelStringInput>;
-  paymentMethod: InputMaybe<ModelStringInput>;
-  price: InputMaybe<ModelFloatInput>;
-  reportDataCustomerOrdersId: InputMaybe<ModelIdInput>;
-  reportDataOrderMobileAppOrderIdId: InputMaybe<ModelIdInput>;
-  updatedAt: InputMaybe<ModelStringInput>;
-  vatRate: InputMaybe<ModelFloatInput>;
 };
 
 export type ModelResultConditionInput = {
@@ -1096,6 +980,7 @@ export type ModelSubscriptionPackageFilterInput = {
   description: InputMaybe<ModelSubscriptionStringInput>;
   id: InputMaybe<ModelSubscriptionIdInput>;
   images: InputMaybe<ModelSubscriptionStringInput>;
+  isDiscontinued: InputMaybe<ModelSubscriptionBooleanInput>;
   meta_data: InputMaybe<ModelSubscriptionStringInput>;
   name: InputMaybe<ModelSubscriptionStringInput>;
   or: InputMaybe<Array<InputMaybe<ModelSubscriptionPackageFilterInput>>>;
@@ -1150,40 +1035,6 @@ export type ModelSubscriptionProductFilterInput = {
   sku: InputMaybe<ModelSubscriptionStringInput>;
   tax_class: InputMaybe<ModelSubscriptionStringInput>;
   updatedAt: InputMaybe<ModelSubscriptionStringInput>;
-};
-
-export type ModelSubscriptionReportDataCustomerFilterInput = {
-  and: InputMaybe<Array<InputMaybe<ModelSubscriptionReportDataCustomerFilterInput>>>;
-  createdAt: InputMaybe<ModelSubscriptionStringInput>;
-  email: InputMaybe<ModelSubscriptionStringInput>;
-  firstName: InputMaybe<ModelSubscriptionStringInput>;
-  id: InputMaybe<ModelSubscriptionIdInput>;
-  language: InputMaybe<ModelSubscriptionStringInput>;
-  lastName: InputMaybe<ModelSubscriptionStringInput>;
-  mobileAppCustomerId: InputMaybe<ModelSubscriptionIdInput>;
-  or: InputMaybe<Array<InputMaybe<ModelSubscriptionReportDataCustomerFilterInput>>>;
-  phoneNumber: InputMaybe<ModelSubscriptionStringInput>;
-  reportDataCustomerOrdersId: InputMaybe<ModelSubscriptionIdInput>;
-  resultsReadyDate: InputMaybe<ModelSubscriptionStringInput>;
-  updatedAt: InputMaybe<ModelSubscriptionStringInput>;
-};
-
-export type ModelSubscriptionReportDataOrderFilterInput = {
-  and: InputMaybe<Array<InputMaybe<ModelSubscriptionReportDataOrderFilterInput>>>;
-  campaign: InputMaybe<ModelSubscriptionStringInput>;
-  coupon: InputMaybe<ModelSubscriptionStringInput>;
-  createdAt: InputMaybe<ModelSubscriptionStringInput>;
-  details: InputMaybe<ModelSubscriptionStringInput>;
-  discount: InputMaybe<ModelSubscriptionFloatInput>;
-  id: InputMaybe<ModelSubscriptionIdInput>;
-  or: InputMaybe<Array<InputMaybe<ModelSubscriptionReportDataOrderFilterInput>>>;
-  orderDate: InputMaybe<ModelSubscriptionStringInput>;
-  orderSource: InputMaybe<ModelSubscriptionStringInput>;
-  paymentMethod: InputMaybe<ModelSubscriptionStringInput>;
-  price: InputMaybe<ModelSubscriptionFloatInput>;
-  reportDataOrderMobileAppOrderIdId: InputMaybe<ModelSubscriptionIdInput>;
-  updatedAt: InputMaybe<ModelSubscriptionStringInput>;
-  vatRate: InputMaybe<ModelSubscriptionFloatInput>;
 };
 
 export type ModelSubscriptionResultFilterInput = {
@@ -1287,8 +1138,6 @@ export type Mutation = {
   createPackageProduct: Maybe<PackageProduct>;
   createPayment: Maybe<Payment>;
   createProduct: Maybe<Product>;
-  createReportDataCustomer: Maybe<ReportDataCustomer>;
-  createReportDataOrder: Maybe<ReportDataOrder>;
   createResult: Maybe<Result>;
   createSample: Maybe<Sample>;
   createWebadminSample: Maybe<WebadminSample>;
@@ -1301,8 +1150,6 @@ export type Mutation = {
   deletePackageProduct: Maybe<PackageProduct>;
   deletePayment: Maybe<Payment>;
   deleteProduct: Maybe<Product>;
-  deleteReportDataCustomer: Maybe<ReportDataCustomer>;
-  deleteReportDataOrder: Maybe<ReportDataOrder>;
   deleteResult: Maybe<Result>;
   deleteSample: Maybe<Sample>;
   deleteWebadminSample: Maybe<WebadminSample>;
@@ -1315,8 +1162,6 @@ export type Mutation = {
   updatePackageProduct: Maybe<PackageProduct>;
   updatePayment: Maybe<Payment>;
   updateProduct: Maybe<Product>;
-  updateReportDataCustomer: Maybe<ReportDataCustomer>;
-  updateReportDataOrder: Maybe<ReportDataOrder>;
   updateResult: Maybe<Result>;
   updateSample: Maybe<Sample>;
   updateWebadminSample: Maybe<WebadminSample>;
@@ -1374,18 +1219,6 @@ export type MutationCreatePaymentArgs = {
 export type MutationCreateProductArgs = {
   condition: InputMaybe<ModelProductConditionInput>;
   input: CreateProductInput;
-};
-
-
-export type MutationCreateReportDataCustomerArgs = {
-  condition: InputMaybe<ModelReportDataCustomerConditionInput>;
-  input: CreateReportDataCustomerInput;
-};
-
-
-export type MutationCreateReportDataOrderArgs = {
-  condition: InputMaybe<ModelReportDataOrderConditionInput>;
-  input: CreateReportDataOrderInput;
 };
 
 
@@ -1461,18 +1294,6 @@ export type MutationDeleteProductArgs = {
 };
 
 
-export type MutationDeleteReportDataCustomerArgs = {
-  condition: InputMaybe<ModelReportDataCustomerConditionInput>;
-  input: DeleteReportDataCustomerInput;
-};
-
-
-export type MutationDeleteReportDataOrderArgs = {
-  condition: InputMaybe<ModelReportDataOrderConditionInput>;
-  input: DeleteReportDataOrderInput;
-};
-
-
 export type MutationDeleteResultArgs = {
   condition: InputMaybe<ModelResultConditionInput>;
   input: DeleteResultInput;
@@ -1545,18 +1366,6 @@ export type MutationUpdateProductArgs = {
 };
 
 
-export type MutationUpdateReportDataCustomerArgs = {
-  condition: InputMaybe<ModelReportDataCustomerConditionInput>;
-  input: UpdateReportDataCustomerInput;
-};
-
-
-export type MutationUpdateReportDataOrderArgs = {
-  condition: InputMaybe<ModelReportDataOrderConditionInput>;
-  input: UpdateReportDataOrderInput;
-};
-
-
 export type MutationUpdateResultArgs = {
   condition: InputMaybe<ModelResultConditionInput>;
   input: UpdateResultInput;
@@ -1621,6 +1430,7 @@ export type Package = {
   description: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   images: Maybe<Array<Maybe<Scalars['AWSURL']['output']>>>;
+  isDiscontinued: Maybe<Scalars['Boolean']['output']>;
   meta_data: Maybe<Scalars['String']['output']>;
   name: Maybe<Scalars['String']['output']>;
   orders: Maybe<ModelOrderPackageConnection>;
@@ -1673,7 +1483,6 @@ export type Payment = {
   packageCodes: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
   provider: Maybe<PaymentProvider>;
   status: Maybe<PaymentStatus>;
-  stripeMetadata: Maybe<StripePaymentMetadata>;
   updatedAt: Scalars['AWSDateTime']['output'];
   userId: Maybe<Scalars['ID']['output']>;
 };
@@ -1732,7 +1541,6 @@ export enum ProductType {
 
 export type Query = {
   __typename?: 'Query';
-  RDCustomerByMobAppCustomerId: Maybe<ModelReportDataCustomerConnection>;
   customerByHasBoughtMainPackage: Maybe<ModelCustomerConnection>;
   customerByPhoneNumber: Maybe<ModelCustomerConnection>;
   customerScanByUpdatedAt: Maybe<ModelCustomerConnection>;
@@ -1748,8 +1556,6 @@ export type Query = {
   getPayment: Maybe<Payment>;
   getProduct: Maybe<Product>;
   getProductByCode: Maybe<ModelProductConnection>;
-  getReportDataCustomer: Maybe<ReportDataCustomer>;
-  getReportDataOrder: Maybe<ReportDataOrder>;
   getResult: Maybe<Result>;
   getSample: Maybe<Sample>;
   getSampleByName: Maybe<ModelSampleConnection>;
@@ -1763,8 +1569,6 @@ export type Query = {
   listPackages: Maybe<ModelPackageConnection>;
   listPayments: Maybe<ModelPaymentConnection>;
   listProducts: Maybe<ModelProductConnection>;
-  listReportDataCustomers: Maybe<ModelReportDataCustomerConnection>;
-  listReportDataOrders: Maybe<ModelReportDataOrderConnection>;
   listResults: Maybe<ModelResultConnection>;
   listSamples: Maybe<ModelSampleConnection>;
   listWebadminSamples: Maybe<ModelWebadminSampleConnection>;
@@ -1776,15 +1580,6 @@ export type Query = {
   resultByOwner: Maybe<ModelResultConnection>;
   sampleByCustomer: Maybe<ModelSampleConnection>;
   webadminSampleByCustomer: Maybe<ModelWebadminSampleConnection>;
-};
-
-
-export type QueryRdCustomerByMobAppCustomerIdArgs = {
-  filter: InputMaybe<ModelReportDataCustomerFilterInput>;
-  limit: InputMaybe<Scalars['Int']['input']>;
-  mobileAppCustomerId: Scalars['ID']['input'];
-  nextToken: InputMaybe<Scalars['String']['input']>;
-  sortDirection: InputMaybe<ModelSortDirection>;
 };
 
 
@@ -1889,16 +1684,6 @@ export type QueryGetProductByCodeArgs = {
 };
 
 
-export type QueryGetReportDataCustomerArgs = {
-  id: Scalars['ID']['input'];
-};
-
-
-export type QueryGetReportDataOrderArgs = {
-  id: Scalars['ID']['input'];
-};
-
-
 export type QueryGetResultArgs = {
   id: Scalars['ID']['input'];
 };
@@ -1981,20 +1766,6 @@ export type QueryListPaymentsArgs = {
 
 export type QueryListProductsArgs = {
   filter: InputMaybe<ModelProductFilterInput>;
-  limit: InputMaybe<Scalars['Int']['input']>;
-  nextToken: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type QueryListReportDataCustomersArgs = {
-  filter: InputMaybe<ModelReportDataCustomerFilterInput>;
-  limit: InputMaybe<Scalars['Int']['input']>;
-  nextToken: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type QueryListReportDataOrdersArgs = {
-  filter: InputMaybe<ModelReportDataOrderFilterInput>;
   limit: InputMaybe<Scalars['Int']['input']>;
   nextToken: InputMaybe<Scalars['String']['input']>;
 };
@@ -2098,63 +1869,6 @@ export type QueryWebadminSampleByCustomerArgs = {
   webadminSampleCustomerId: Scalars['ID']['input'];
 };
 
-export type ReportDataCustomer = {
-  __typename?: 'ReportDataCustomer';
-  address: Maybe<Address>;
-  createdAt: Scalars['AWSDateTime']['output'];
-  customer: Maybe<Customer>;
-  email: Maybe<Scalars['String']['output']>;
-  firstName: Maybe<Scalars['String']['output']>;
-  id: Scalars['ID']['output'];
-  language: Maybe<Scalars['String']['output']>;
-  lastName: Maybe<Scalars['String']['output']>;
-  mobileAppCustomerId: Maybe<Scalars['ID']['output']>;
-  orders: Maybe<ModelReportDataOrderConnection>;
-  phoneNumber: Maybe<Scalars['String']['output']>;
-  resultsReadyDate: Maybe<Scalars['String']['output']>;
-  updatedAt: Scalars['AWSDateTime']['output'];
-};
-
-
-export type ReportDataCustomerOrdersArgs = {
-  filter: InputMaybe<ModelReportDataOrderFilterInput>;
-  limit: InputMaybe<Scalars['Int']['input']>;
-  nextToken: InputMaybe<Scalars['String']['input']>;
-  sortDirection: InputMaybe<ModelSortDirection>;
-};
-
-export type ReportDataOrder = {
-  __typename?: 'ReportDataOrder';
-  campaign: Maybe<Scalars['String']['output']>;
-  coupon: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['AWSDateTime']['output'];
-  customer: Maybe<ReportDataCustomer>;
-  details: Maybe<Scalars['String']['output']>;
-  discount: Maybe<Scalars['Float']['output']>;
-  id: Scalars['ID']['output'];
-  mobileAppOrderId: Maybe<Order>;
-  orderDate: Maybe<Scalars['String']['output']>;
-  orderSource: Maybe<Scalars['String']['output']>;
-  paymentMethod: Maybe<Scalars['String']['output']>;
-  price: Maybe<Scalars['Float']['output']>;
-  products: Maybe<Array<Maybe<ReportDataProduct>>>;
-  reportDataCustomerOrdersId: Maybe<Scalars['ID']['output']>;
-  reportDataOrderMobileAppOrderIdId: Maybe<Scalars['ID']['output']>;
-  updatedAt: Scalars['AWSDateTime']['output'];
-  vatRate: Maybe<Scalars['Float']['output']>;
-};
-
-export type ReportDataProduct = {
-  __typename?: 'ReportDataProduct';
-  name: Maybe<Scalars['String']['output']>;
-  price: Maybe<Scalars['Float']['output']>;
-};
-
-export type ReportDataProductInput = {
-  name: InputMaybe<Scalars['String']['input']>;
-  price: InputMaybe<Scalars['Float']['input']>;
-};
-
 export type Result = {
   __typename?: 'Result';
   createdAt: Scalars['AWSDateTime']['output'];
@@ -2198,15 +1912,6 @@ export enum SampleStatus {
   Sent = 'SENT'
 }
 
-export type StripePaymentMetadata = {
-  __typename?: 'StripePaymentMetadata';
-  paymentIntentId: Maybe<Scalars['String']['output']>;
-};
-
-export type StripePaymentMetadataInput = {
-  paymentIntentId: InputMaybe<Scalars['String']['input']>;
-};
-
 export type Subscription = {
   __typename?: 'Subscription';
   onCreateConfig: Maybe<Config>;
@@ -2218,8 +1923,6 @@ export type Subscription = {
   onCreatePackageProduct: Maybe<PackageProduct>;
   onCreatePayment: Maybe<Payment>;
   onCreateProduct: Maybe<Product>;
-  onCreateReportDataCustomer: Maybe<ReportDataCustomer>;
-  onCreateReportDataOrder: Maybe<ReportDataOrder>;
   onCreateResult: Maybe<Result>;
   onCreateSample: Maybe<Sample>;
   onCreateWebadminSample: Maybe<WebadminSample>;
@@ -2232,8 +1935,6 @@ export type Subscription = {
   onDeletePackageProduct: Maybe<PackageProduct>;
   onDeletePayment: Maybe<Payment>;
   onDeleteProduct: Maybe<Product>;
-  onDeleteReportDataCustomer: Maybe<ReportDataCustomer>;
-  onDeleteReportDataOrder: Maybe<ReportDataOrder>;
   onDeleteResult: Maybe<Result>;
   onDeleteSample: Maybe<Sample>;
   onDeleteWebadminSample: Maybe<WebadminSample>;
@@ -2246,8 +1947,6 @@ export type Subscription = {
   onUpdatePackageProduct: Maybe<PackageProduct>;
   onUpdatePayment: Maybe<Payment>;
   onUpdateProduct: Maybe<Product>;
-  onUpdateReportDataCustomer: Maybe<ReportDataCustomer>;
-  onUpdateReportDataOrder: Maybe<ReportDataOrder>;
   onUpdateResult: Maybe<Result>;
   onUpdateSample: Maybe<Sample>;
   onUpdateWebadminSample: Maybe<WebadminSample>;
@@ -2301,16 +2000,6 @@ export type SubscriptionOnCreatePaymentArgs = {
 
 export type SubscriptionOnCreateProductArgs = {
   filter: InputMaybe<ModelSubscriptionProductFilterInput>;
-};
-
-
-export type SubscriptionOnCreateReportDataCustomerArgs = {
-  filter: InputMaybe<ModelSubscriptionReportDataCustomerFilterInput>;
-};
-
-
-export type SubscriptionOnCreateReportDataOrderArgs = {
-  filter: InputMaybe<ModelSubscriptionReportDataOrderFilterInput>;
 };
 
 
@@ -2382,16 +2071,6 @@ export type SubscriptionOnDeleteProductArgs = {
 };
 
 
-export type SubscriptionOnDeleteReportDataCustomerArgs = {
-  filter: InputMaybe<ModelSubscriptionReportDataCustomerFilterInput>;
-};
-
-
-export type SubscriptionOnDeleteReportDataOrderArgs = {
-  filter: InputMaybe<ModelSubscriptionReportDataOrderFilterInput>;
-};
-
-
 export type SubscriptionOnDeleteResultArgs = {
   filter: InputMaybe<ModelSubscriptionResultFilterInput>;
   owner: InputMaybe<Scalars['String']['input']>;
@@ -2457,16 +2136,6 @@ export type SubscriptionOnUpdatePaymentArgs = {
 
 export type SubscriptionOnUpdateProductArgs = {
   filter: InputMaybe<ModelSubscriptionProductFilterInput>;
-};
-
-
-export type SubscriptionOnUpdateReportDataCustomerArgs = {
-  filter: InputMaybe<ModelSubscriptionReportDataCustomerFilterInput>;
-};
-
-
-export type SubscriptionOnUpdateReportDataOrderArgs = {
-  filter: InputMaybe<ModelSubscriptionReportDataOrderFilterInput>;
 };
 
 
@@ -2547,6 +2216,7 @@ export type UpdatePackageInput = {
   description: InputMaybe<Scalars['String']['input']>;
   id: Scalars['ID']['input'];
   images: InputMaybe<Array<InputMaybe<Scalars['AWSURL']['input']>>>;
+  isDiscontinued: InputMaybe<Scalars['Boolean']['input']>;
   meta_data: InputMaybe<Scalars['String']['input']>;
   name: InputMaybe<Scalars['String']['input']>;
   price: InputMaybe<Scalars['String']['input']>;
@@ -2573,7 +2243,6 @@ export type UpdatePaymentInput = {
   packageCodes: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
   provider: InputMaybe<PaymentProvider>;
   status: InputMaybe<PaymentStatus>;
-  stripeMetadata: InputMaybe<StripePaymentMetadataInput>;
   userId: InputMaybe<Scalars['ID']['input']>;
 };
 
@@ -2589,34 +2258,6 @@ export type UpdateProductInput = {
   short_description: InputMaybe<Scalars['String']['input']>;
   sku: InputMaybe<Scalars['String']['input']>;
   tax_class: InputMaybe<Scalars['String']['input']>;
-};
-
-export type UpdateReportDataCustomerInput = {
-  address: InputMaybe<AddressInput>;
-  email: InputMaybe<Scalars['String']['input']>;
-  firstName: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['ID']['input'];
-  language: InputMaybe<Scalars['String']['input']>;
-  lastName: InputMaybe<Scalars['String']['input']>;
-  mobileAppCustomerId: InputMaybe<Scalars['ID']['input']>;
-  phoneNumber: InputMaybe<Scalars['String']['input']>;
-  resultsReadyDate: InputMaybe<Scalars['String']['input']>;
-};
-
-export type UpdateReportDataOrderInput = {
-  campaign: InputMaybe<Scalars['String']['input']>;
-  coupon: InputMaybe<Scalars['String']['input']>;
-  details: InputMaybe<Scalars['String']['input']>;
-  discount: InputMaybe<Scalars['Float']['input']>;
-  id: Scalars['ID']['input'];
-  orderDate: InputMaybe<Scalars['String']['input']>;
-  orderSource: InputMaybe<Scalars['String']['input']>;
-  paymentMethod: InputMaybe<Scalars['String']['input']>;
-  price: InputMaybe<Scalars['Float']['input']>;
-  products: InputMaybe<Array<InputMaybe<ReportDataProductInput>>>;
-  reportDataCustomerOrdersId: InputMaybe<Scalars['ID']['input']>;
-  reportDataOrderMobileAppOrderIdId: InputMaybe<Scalars['ID']['input']>;
-  vatRate: InputMaybe<Scalars['Float']['input']>;
 };
 
 export type UpdateResultInput = {
@@ -2667,9 +2308,9 @@ export enum WebadminSampleStatus {
   SentToLab = 'SENT_TO_LAB'
 }
 
-export type ProductFragment = { __typename?: 'Product', id: string, name: string, productCode: string };
+export type ProductFragment = { __typename?: 'Product', id: string, name: string, productCode: string, packages: { __typename?: 'ModelPackageProductConnection', items: Array<{ __typename?: 'PackageProduct', packageID: string, package: { __typename?: 'Package', id: string, isDiscontinued: boolean | null } } | null> } | null };
 
-export type UserOrderFragment = { __typename?: 'OrderPackage', id: string, package: { __typename?: 'Package', id: string, name: string | null, productCode: number | null, productType: ProductType | null, createdAt: any } };
+export type UserOrderFragment = { __typename?: 'OrderPackage', id: string, package: { __typename?: 'Package', id: string, name: string | null, productCode: number | null, productType: ProductType | null, createdAt: any, isDiscontinued: boolean | null } };
 
 export type GetUserOrdersAndPackagesQueryVariables = Exact<{
   userId: Scalars['ID']['input'];
@@ -2677,7 +2318,7 @@ export type GetUserOrdersAndPackagesQueryVariables = Exact<{
 }>;
 
 
-export type GetUserOrdersAndPackagesQuery = { __typename?: 'Query', orderByOwner: { __typename?: 'ModelOrderConnection', nextToken: string | null, items: Array<{ __typename?: 'Order', id: string, packages: { __typename?: 'ModelOrderPackageConnection', items: Array<{ __typename?: 'OrderPackage', id: string, package: { __typename?: 'Package', id: string, name: string | null, productCode: number | null, productType: ProductType | null, createdAt: any } } | null> } | null } | null> } | null };
+export type GetUserOrdersAndPackagesQuery = { __typename?: 'Query', orderByOwner: { __typename?: 'ModelOrderConnection', nextToken: string | null, items: Array<{ __typename?: 'Order', id: string, packages: { __typename?: 'ModelOrderPackageConnection', items: Array<{ __typename?: 'OrderPackage', id: string, package: { __typename?: 'Package', id: string, name: string | null, productCode: number | null, productType: ProductType | null, createdAt: any, isDiscontinued: boolean | null } } | null> } | null } | null> } | null };
 
 export type UserResultFragment = { __typename?: 'Result', id: string, name: string, description: string | null, createdAt: any, sampleResultsId: string | null, productResultsId: string | null, value: number };
 
@@ -2694,13 +2335,22 @@ export type ListProductsQueryVariables = Exact<{
 }>;
 
 
-export type ListProductsQuery = { __typename?: 'Query', listProducts: { __typename?: 'ModelProductConnection', nextToken: string | null, items: Array<{ __typename?: 'Product', id: string, name: string, productCode: string } | null> } | null };
+export type ListProductsQuery = { __typename?: 'Query', listProducts: { __typename?: 'ModelProductConnection', nextToken: string | null, items: Array<{ __typename?: 'Product', id: string, name: string, productCode: string, packages: { __typename?: 'ModelPackageProductConnection', items: Array<{ __typename?: 'PackageProduct', packageID: string, package: { __typename?: 'Package', id: string, isDiscontinued: boolean | null } } | null> } | null } | null> } | null };
 
 export const ProductFragmentDoc = gql`
     fragment Product on Product {
   id
   name
   productCode
+  packages {
+    items {
+      packageID
+      package {
+        id
+        isDiscontinued
+      }
+    }
+  }
 }
     `;
 export const UserOrderFragmentDoc = gql`
@@ -2712,6 +2362,7 @@ export const UserOrderFragmentDoc = gql`
     productCode
     productType
     createdAt
+    isDiscontinued
   }
 }
     `;

--- a/src/evogenom-api-client/query.ts
+++ b/src/evogenom-api-client/query.ts
@@ -5,6 +5,15 @@ export const ProductFragment = gql`
     id
     name
     productCode
+    packages {
+      items {
+        packageID
+        package {
+          id
+          isDiscontinued
+        }
+      }
+    }
   }
 `;
 
@@ -17,6 +26,7 @@ export const UserOrderFragement = gql`
       productCode
       productType
       createdAt
+      isDiscontinued
     }
   }
 `;


### PR DESCRIPTION
- Reintroduced the schema definition for queries, mutations, and subscriptions.
- Updated the ResultService to filter out products with only discontinued packages.
- Modified GraphQL types to include `isDiscontinued` for packages and products.
- Removed unused report data types and related mutations from the schema.
- Enhanced unit tests to validate filtering logic for products based on package status.